### PR TITLE
ci: assign author to pr

### DIFF
--- a/.github/workflows/assign-pr.yml
+++ b/.github/workflows/assign-pr.yml
@@ -1,0 +1,18 @@
+name: Assign author to PR
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  assign-pr:
+    # skip already assigned PRs
+    if: ${{ toJSON(github.event.pull_request.assignees) == '[]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: gh pr edit $PR_NUMBER --add-assignee $PR_AUTHOR


### PR DESCRIPTION
## Overview (Required)
- assign author to pr when PR opened
  - This change displays the assignee for each PR on the list screen, making it easier to see who is working on what

Without an assignee, it becomes unclear who is responsible for a PR
<img width="1194" height="832" alt="スクリーンショット 2025-07-21 19 54 40" src="https://github.com/user-attachments/assets/351aeb79-ebd9-4824-b6ee-050fb98142c3" />


## Operation check
- tested the workflow trigger on a PR push.
- https://github.com/DroidKaigi/conference-app-2025/actions/runs/16414925592/job/46378534022?pr=15
