### PR TITLE
ci: run build on files related to android changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,37 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - 'app-ios/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions: {}
+permissions: { }
 
 jobs:
+  setup-job:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.changes.outputs.android }}
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - name: Check code changes related to Android
+        uses: dorny/paths-filter@v3.0.2
+        id: changes
+        with:
+          filters: |
+            android:
+              - '**/*.kt'
+              - '**/*.kts'
+              - '**/*.xml'
+              - 'gradle/libs.versions.toml'
+
   build:
+    needs: setup-job
+    if: ${{ needs.setup-job.outputs.android == 'true' }}
     permissions:
       contents: read
 


### PR DESCRIPTION
## Overview (Required)
- run `build` on files related to android changed

## Detail

This PR fixes an issue where a required status check gets stuck in a "pending" state. This happens when the entire workflow is skipped due to a paths-ignore filter, which prevents the PR from being merged.

To resolve this, the workflow is now configured to always trigger. A new step within the job checks for relevant file changes to determine whether the subsequent steps should run. Because the job itself completes successfully (even when most steps are skipped), it reports a "success" status. This satisfies the required check and allows the PR to be merged.

## Links
- [モノレポでマージキューと必須ステータスチェックを運用するためのTips](https://tech.route06.co.jp/entry/2024/06/12/121511)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
After files related to android changes, run `build`
https://github.com/DroidKaigi/conference-app-2025/actions/runs/16416599205
<img width="827" height="101" alt="スクリーンショット 2025-07-21 21 14 17" src="https://github.com/user-attachments/assets/b66fc7fe-e8ce-4c86-8642-902ed0f596c3" />

Because changed files dont contain files related to android, skip `build`
https://github.com/DroidKaigi/conference-app-2025/actions/runs/16416139375
<img width="838" height="167" alt="スクリーンショット 2025-07-21 21 06 24" src="https://github.com/user-attachments/assets/25d93547-73bd-4ce4-bb68-70bdf836fcc3" />
