### PR TITLE
Set up screenshot testing on CI

### DIFF
--- a/.github/workflows/screenshot-comparison.yml
+++ b/.github/workflows/screenshot-comparison.yml
@@ -48,7 +48,7 @@ jobs:
           commit: ${{ steps.get_base_branch_head.outputs.sha }}
           if_no_artifact_found: fail
 
-      - run: ./gradlew compareRoborazziDebug compareRoborazziDevDebug --stacktrace
+      - run: ./gradlew compareRoborazziDebug --stacktrace
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()


### PR DESCRIPTION
## Overview (Required)
- Add `screenshot-comparison.yml` to run screenshot tests on CI (almost the same as last year).
- The workflow that comments on screenshot differences in PRs cannot be added yet because it relies on `workflow_run` as a trigger event, which will not fire unless the target workflows exist in the default branch. I will address this in a separate PR.