### PR TITLE
Bump compose multiplatform to 1.9.0-beta01

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -69,9 +69,9 @@ dependencies {
     implementation(projects.feature.contributors)
 
     implementation(compose.runtime)
-    implementation(compose.material3)
     implementation(compose.components.uiToolingPreview)
     implementation(compose.materialIconsExtended)
+    implementation(libs.material3)
     debugImplementation(compose.uiTooling)
 
     implementation(libs.androidxActivityCompose)

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 }
 
 dependencies {
-    commonMainImplementation(compose.material3)
+    commonMainImplementation(libs.material3)
 }

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -28,7 +28,6 @@ kotlin {
             @OptIn(ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)
             implementation(compose.runtime)
-            implementation(compose.material3)
             implementation(compose.components.uiToolingPreview)
             implementation(compose.components.resources)
 
@@ -37,6 +36,7 @@ kotlin {
             implementation(libs.lifecycleViewmodelCompose)
             implementation(libs.lifecycleRuntimeCompose)
             implementation(libs.androidxDatastorePreferencesCore)
+            implementation(libs.material3)
         }
 
         androidMain.dependencies {

--- a/gradle-conventions/src/main/kotlin/droidkaigi/primitive/kmp.compose.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/droidkaigi/primitive/kmp.compose.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 
 dependencies {
     commonMainImplementation(compose.ui)
-    commonMainImplementation(compose.material3)
     commonMainImplementation(compose.components.uiToolingPreview)
     commonMainImplementation(compose.materialIconsExtended)
     commonMainImplementation(libs.library("rin"))
+    commonMainImplementation(libs.library("material3"))
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.2.0"
 ksp = "2.2.0-2.0.2"
 
 jetbrainsCompose = "1.9.0-beta01"
+material3 = "1.9.0-alpha04"
 
 kotlinPoet = "2.2.0"
 kotlinxSerialization = "1.9.0"
@@ -121,6 +122,8 @@ navigationeventDesktop = { group = "androidx.navigationevent", name = "navigatio
 coil = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coilNetwork = { module = "io.coil-kt.coil3:coil-network-ktor2", version.ref = "coil" }
 coilTest = { module = "io.coil-kt.coil3:coil-test", version.ref = "coil" }
+
+material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
## Overview (Required)
- Bump Compose Multiplatform to `1.9.0-beta01`.
- Add the Material3 dependency explicitly to avoid unresolved references to Material3-Expressive-only symbols.
  - Since CMP 1.9.0-beta01, Material3 versioning has been decoupled. See [the official release note](https://www.jetbrains.com/help/kotlin-multiplatform-dev/whats-new-compose-190.html#decoupled-material3-versioning) for more information.
