### PR TITLE
Run unit tests on CI

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -35,9 +35,6 @@ jobs:
 
       - run: ./gradlew testDevDebugUnitTest testDebugUnitTest --stacktrace
 
-      # Saving cost
-      # - run: ./gradlew koverHtmlReportDevDebug --stacktrace
-
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:


### PR DESCRIPTION
## Overview (Required)
- Add unit-test.yml to run unit tests on CI (almost the same as last year).
- This workflow includes a step to upload test reports.
- To run the screenshot-comparison workflow, the unit-test workflow on the main branch must be completed first (this PR is blocking #21).

Therefore, I’d like to merge this PR first.