### PR TITLE
Remove explicit dependsOn from kmp.roborazzi plugin

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(projects.core.droidkaigiui)
-            implementation(projects.core.model)
+            api(projects.core.model)
             implementation(projects.core.common)
             implementation(projects.core.droidkaigiui)
             implementation(projects.core.designsystem)

--- a/gradle-conventions/src/main/kotlin/droidkaigi/primitive/kmp.roborazzi.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/droidkaigi/primitive/kmp.roborazzi.gradle.kts
@@ -30,10 +30,6 @@ configure<BaseExtension> {
 kotlin {
     sourceSets {
         androidUnitTest {
-            // This explicit dependency is required to avoid unresolved references when referencing other module types.
-            // This might be due to some modules using 'com.android.kotlin.multiplatform.library' instead of 'com.android.library'.
-            // FIXME: This inconsistency could potentially cause issues, so it's probably better to use the same plugin in all modules.
-            dependsOn(androidMain.get())
             dependencies {
                 implementation(libs.library("roborazziPreviewScannerSupport"))
                 implementation(libs.library("composablePreviewScannerAndroid"))


### PR DESCRIPTION
## Overview (Required)
- Explicit `dependsOn` should generally be avoided.
- To compile `TimetableScreenTest` successfully, I previously added an explicit dependency from `androidUnitTest` to `androidMain` in [PR #19](https://github.com/DroidKaigi/conference-app-2025/pull/19#discussion_r2225865358).
- My assumption at that time was incorrect; simply adding the `model` module as an `api` dependency resolved the issue.

## Screenshot (Optional if screenshot test is present or unrelated to UI)

If `implementation` is used, the following compilation error will occur:
<img width="1409" height="618" alt="image" src="https://github.com/user-attachments/assets/c8d7d5fd-e2e0-4b28-9bf4-7fea94b2b4c2" />

After replacing it with `api`, the tests compile successfully even without explicit `dependsOn`:
<img width="1409" height="618" alt="image" src="https://github.com/user-attachments/assets/8012e0bd-8e89-479b-8e4a-baf399f2528a" />