### PR TITLE
Bump ktorfit to 2.6.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ androidxTestCore = "1.6.1"
 androidxBrowser = "1.8.0"
 
 ktor = "3.2.1"
-ktorfit = "2.6.1"
+ktorfit = "2.6.2"
 
 soil = "1.0.0-alpha11"
 


### PR DESCRIPTION
## Overview (Required)
- This PR addresses the JDK 21 requirement issue.
- See the Ktorfit changelog: https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md