### PR TITLE
Adaptive column count for TimetableList

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/KaigiWindowSizeClassConstants.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/KaigiWindowSizeClassConstants.kt
@@ -1,0 +1,14 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.ui.unit.dp
+
+/**
+ * The threshold values for each window size class are not publicly accessible,
+ * so we define them here for reference.
+ *
+ * As Navigation 3 supports two-pane layouts, we sometimes need to determine
+ * the layout manually by comparing the available size with each window size class.
+ */
+object KaigiWindowSizeClassConstants {
+    val WindowWidthSizeClassMediumMinWidth = 600.dp
+}


### PR DESCRIPTION
## Overview (Required)
- Use a two-column layout for TimetableList when there is enough available space.
- Since Navigation 3 supports multi-pane layouts, we calculate the available space using `BoxWithConstraints` instead of relying on `WindowWidthSizeClass`. See the expanded screenshot for better understanding.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
WindowWidthSizeClass | Before | After
:--: | :--: | :--:
Compact(Unchanged) | <img width="300" alt="Screenshot_20250727_190100" src="https://github.com/user-attachments/assets/e0c9eebf-331d-4398-9ffc-40c453be9d87" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/23bcc735-c87e-46de-93c1-fb60471b1a88" />
Medium(Changed!!) | <img width="300" alt="image" src="https://github.com/user-attachments/assets/7e2c36dc-2d0f-44aa-b0af-c4016a057b04" /> | <img src="https://github.com/user-attachments/assets/fd53d412-e4a8-4216-b115-b8a6e6f84772" width="300" />
Expanded(Unchanged) | <img width="300" alt="image" src="https://github.com/user-attachments/assets/e68956cb-6634-4373-9d54-80743cd0c538" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/56c8c79f-32f8-4ce3-961d-4a2b85f29ad7" />