### PR TITLE
Add workflow to report screenshot diffs as PR comments

### DIFF
--- a/.github/workflows/screenshot-comparison-comment.yml
+++ b/.github/workflows/screenshot-comparison-comment.yml
@@ -131,7 +131,7 @@ jobs:
           body-includes: Snapshot diff report
 
       - name: Add or update comment on PR
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         if: steps.generate-diff-reports.outputs.reports != ''
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
## Overview (Required)
- Add `screenshot-comparison-diff.yml` to comment on differences detected during screenshot testing.
- This is basically the same as last year's implementation, with each workflow action upgraded.
- Not tested yet because `workflow_run` cannot be triggered if the workflow that uses this trigger rule does not exist on the main branch.
- After merging this PR, I will test it by opening a new PR. So please just review briefly and approve if there are no major issues. 🙏🏻 