### PR TITLE
Fix: Timetable becomes empty after a few seconds on iOS

### DIFF
--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/SessionsRepository.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/SessionsRepository.kt
@@ -51,6 +51,6 @@ class SessionsRepository(
         .filterNotNull()
         .catch {
             // Errors thrown inside flow can't be caught on iOS side, so we catch it here.
-            it.printStackTrace()
+            emit(Timetable())
         }
 }


### PR DESCRIPTION
## Overview (Required)
- Fixed an issue where timetable data was unexpectedly emitted as empty after 5 seconds.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/666faeab-e182-4522-8d43-8e897a5fd08b" width="300" > | <video src="https://github.com/user-attachments/assets/442c8d4b-9ddd-4bc0-b140-06b38575d4ac" width="300" >