### PR TITLE
Build XCFramework on CI

### DIFF
--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -1,0 +1,33 @@
+name: build xcframework
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+
+      - uses: ./.github/actions/setup-java
+
+      - run: |
+          ./gradlew :app-shared:assembleSharedDebugXCFramework \
+          -Papp.ios.shared.arch=arm64SimulatorDebug \
+          --stacktrace
+
+      - name: Upload build outputs (APKs)
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-ios-shared-xcframework
+          path: app-shared/build/XCFrameworks


### PR DESCRIPTION
## Overview (Required)
- Add workflow to build KMP XCFramework to ensure successful compilation.