### PR TITLE
Fixed build errors in iOS projects caused by shared library updates.

### DIFF
--- a/app-ios/Native/Sources/Root/KMP/EventMapUseCaseImpl.swift
+++ b/app-ios/Native/Sources/Root/KMP/EventMapUseCaseImpl.swift
@@ -6,12 +6,12 @@ import shared
 struct EventMapUseCaseImpl {
     func load() async throws(LoadEventError) -> [Model.EventMapEvent] {
         // TODO: implement actual kmp connection
-        return await EventMapEvent.mockEvents
+        return await Model.EventMapEvent.mockEvents
     }
 }
 
-extension EventMapEvent {
-    @MainActor static let mockEvents: [EventMapEvent] = [
+extension Model.EventMapEvent {
+    @MainActor static let mockEvents: [Model.EventMapEvent] = [
         EventMapEvent(
             id: "1",
             title: "Welcome Talk",

--- a/app-ios/Native/Sources/Root/KMP/KMPKaigiAppViewControllerWrapper.swift
+++ b/app-ios/Native/Sources/Root/KMP/KMPKaigiAppViewControllerWrapper.swift
@@ -5,7 +5,7 @@ import shared
 @MainActor
 struct KmpAppComposeViewControllerWrapper: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        shared.kaigiAppViewController(appGraph: KMPDependencyProvider.shared.appGraph)
+        shared.KaigiAppViewControllerKt.kaigiAppViewController(appGraph: KMPDependencyProvider.shared.appGraph)
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {

--- a/app-ios/Native/Sources/Root/KMPDependencyProvider.swift
+++ b/app-ios/Native/Sources/Root/KMPDependencyProvider.swift
@@ -6,6 +6,6 @@ public struct KMPDependencyProvider: Sendable {
     public let appGraph: shared.IosAppGraph
 
     private init() {
-        self.appGraph = createIosAppGraph()
+        self.appGraph = IosAppGraphKt.createIosAppGraph()
     }
 }


### PR DESCRIPTION
## Overview (Required)
This PR fixes build errors in the iOS project that were caused by updates to the shared Kotlin Multiplatform (KMP) library. The changes update method signatures and class references to match the latest shared library API.

