### PR TITLE
feat: add FeatureTests target to Native Package.swift

### DIFF
--- a/app-ios/Native/Package.swift
+++ b/app-ios/Native/Package.swift
@@ -33,6 +33,10 @@ let package = Package(
             name: "ComponentTests",
             dependencies: ["Component"]
         ),
+        .testTarget(
+            name: "FeatureTests",
+            dependencies: ["AboutFeature"]
+        ),
         .target(
             name: "DependencyExtra",
             dependencies: [


### PR DESCRIPTION
## Summary
- Add FeatureTests testTarget with dependency on AboutFeature to Native/Package.swift
- Enables AboutPresenterTests.swift to be properly recognized and executed by Swift Package Manager

## Background
The FeatureTests directory and AboutPresenterTests.swift file already exist but were not being executed because there was no corresponding testTarget defined in Package.swift.

## Changes
- Added `FeatureTests` testTarget to Native/Package.swift
- Set dependency on `AboutFeature` module

## Test Plan
- [x] Verify FeatureTests target is recognized by SPM
- [x] Confirm AboutPresenterTests can be executed

🤖 Generated with [Claude Code](https://claude.ai/code)