### PR TITLE
fix: iOS build failure caused by recent changes to rememberXXXScreenContextRetained interface

### DIFF
--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KmpFavoritesScreenPresenter.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KmpFavoritesScreenPresenter.kt
@@ -47,16 +47,18 @@ fun favoritesScreenPresenterStateFlow(
             LocalViewModelStoreOwner provides iosLifecycleOwner,
         ) {
             swrClientProviderWithReturnValue(iosAppGraph.swrClientPlus) {
-                with(iosAppGraph.rememberFavoritesScreenContextRetained()) {
-                    soilDataBoundary(
-                        rememberQuery(timetableQueryKey),
-                        rememberSubscription(favoriteTimetableIdsSubscriptionKey),
-                    ) { timetable, favoriteTimetableItemIds ->
-                        favoritesScreenPresenter(
-                            // To avoid infinite recomposition issues, we use remember to keep the event flow stable.
-                            eventFlow = remember { eventFlow },
-                            timetable = timetable.copy(bookmarks = favoriteTimetableItemIds),
-                        )
+                with(iosAppGraph) {
+                    with(rememberFavoritesScreenContextRetained()) {
+                        soilDataBoundary(
+                            rememberQuery(timetableQueryKey),
+                            rememberSubscription(favoriteTimetableIdsSubscriptionKey),
+                        ) { timetable, favoriteTimetableItemIds ->
+                            favoritesScreenPresenter(
+                                // To avoid infinite recomposition issues, we use remember to keep the event flow stable.
+                                eventFlow = remember { eventFlow },
+                                timetable = timetable.copy(bookmarks = favoriteTimetableItemIds),
+                            )
+                        }
                     }
                 }
             }

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KmpFavoritesScreenViewController.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KmpFavoritesScreenViewController.kt
@@ -25,15 +25,17 @@ fun kmpFavoritesScreenViewController(
         SwrClientProvider(appGraph.swrClientPlus) {
             // Add a constant bottom padding (112.dp) to avoid overlapping with the bottom navigation bar on iOS (value from Figma design).
             CompositionLocalProvider(LocalBottomNavigationBarsPadding provides PaddingValues(bottom = 112.dp)) {
-                with(appGraph.rememberFavoritesScreenContextRetained()) {
-                    FavoritesScreenRoot(
-                        onTimetableItemClick = { timetableItemId ->
-                            // iOS navigation requires the full timetable item data
-                            timetableItems.contents
-                                .firstOrNull { it.timetableItem.id == timetableItemId }
-                                ?.let(onTimetableItemClick)
-                        },
-                    )
+                with(appGraph) {
+                    with(rememberFavoritesScreenContextRetained()) {
+                        FavoritesScreenRoot(
+                            onTimetableItemClick = { timetableItemId ->
+                                // iOS navigation requires the full timetable item data
+                                timetableItems.contents
+                                    .firstOrNull { it.timetableItem.id == timetableItemId }
+                                    ?.let(onTimetableItemClick)
+                            },
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Broken on #108 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
