### PR TITLE
Fix JVM screenshot test by updating Roborazzi to 1.48.0

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -59,8 +59,7 @@ kotlin {
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinTestJunit)
-            // FIXME: If we add the following dependency, compose tests fail. See CaptureScreenRobot.jvm.kt for details.
-//            implementation(libs.roborazziComposeDesktop)
+            implementation(libs.roborazziComposeDesktop)
         }
 
         iosMain.dependencies {

--- a/core/testing/src/jvmMain/kotlin/io/github/droidkaigi/confsched/testing/robot/core/CaptureScreenRobot.jvm.kt
+++ b/core/testing/src/jvmMain/kotlin/io/github/droidkaigi/confsched/testing/robot/core/CaptureScreenRobot.jvm.kt
@@ -2,25 +2,18 @@ package io.github.droidkaigi.confsched.testing.robot.core
 
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import com.github.takahirom.roborazzi.DefaultFileNameGenerator
+import com.github.takahirom.roborazzi.InternalRoborazziApi
+import io.github.takahirom.roborazzi.captureRoboImage
 
+@OptIn(InternalRoborazziApi::class)
 context(composeUiTest: ComposeUiTest)
 actual fun SemanticsNodeInteraction.captureNodeWithDescription(description: String) {
-    /**
-     * No-op for JVM, as we cannot make it work with Roborazzi for now.
-     *
-     * If we add "io.github.takahirom.roborazzi:roborazzi-compose-desktop" to jvm dependencies,
-     * compose tests will fail with the following error:
-     *
-     * ```
-     * 'void androidx.compose.ui.test.AbstractMainTestClock.<init>(kotlinx.coroutines.test.TestCoroutineScheduler, long, kotlin.jvm.functions.Function1)'
-     * java.lang.NoSuchMethodError: 'void androidx.compose.ui.test.AbstractMainTestClock.<init>(kotlinx.coroutines.test.TestCoroutineScheduler, long, kotlin.jvm.functions.Function1)'
-     *     at androidx.compose.ui.test.MainTestClockImpl.<init>(MainTestClockImpl.skikoMain.kt:24)
-     *     at androidx.compose.ui.test.SkikoComposeUiTest.<init>(ComposeUiTest.skiko.kt:203)
-     *     at androidx.compose.ui.test.SkikoComposeUiTest.<init>(ComposeUiTest.skiko.kt)
-     *     at androidx.compose.ui.test.SkikoComposeUiTest.<init>(ComposeUiTest.skiko.kt:153)
-     *     at androidx.compose.ui.test.SkikoComposeUiTest.<init>(ComposeUiTest.skiko.kt:191)
-     *     at androidx.compose.ui.test.SkikoComposeUiTest.<init>(ComposeUiTest.skiko.kt)
-     *     ...
-     * ```
-     */
+    val filePath = DefaultFileNameGenerator.generateFilePath()
+        .split(".")
+        .dropLast(2) // drop method name and extension
+        .joinToString(".")
+        .plus(" - $description.png")
+    println("Capture screen: $filePath")
+    this.captureRoboImage(filePath)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ lifecycleViewmodelNavigation3 = "1.0.0-SNAPSHOT"
 robolectric = "4.15.1"
 
 composeBom = "2025.07.00"
-roborazzi = "1.46.1"
+roborazzi = "1.48.0"
 composablePreviewScanner = "0.6.1"
 junit = "4.13.2"
 


### PR DESCRIPTION
Thank you for the awesome project! @kitakkun
## Issue
- close #124

## Overview (Required)
- Updated Roborazzi from 1.46.1 to 1.48.0 to fix NoSuchMethodError with AbstractMainTestClock on JVM
  - The 1.48.0 has a update of Compose Multiplatform which might fix the problem.
- Implemented captureNodeWithDescription for JVM platform to enable screenshot testing
- Uncommented roborazzi-compose-desktop dependency

## Links
- https://github.com/takahirom/roborazzi/actions/runs/16952566040

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
