### PR TITLE
Fix: Use topAppBarColors for AnimatedMediumTopAppBar

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedMediumTopAppBar.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedMediumTopAppBar.kt
@@ -45,7 +45,7 @@ fun AnimatedMediumTopAppBar(
     modifier: Modifier = Modifier,
     actions: @Composable RowScope.() -> Unit = {},
     windowInsets: WindowInsets = AnimatedMediumTopAppBarDefaults.windowInsets(),
-    colors: TopAppBarColors = TopAppBarDefaults.largeTopAppBarColors().copy(
+    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors().copy(
         scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
     ),
     scrollBehavior: TopAppBarScrollBehavior? = null,


### PR DESCRIPTION
## Issue
- close #174

## Overview (Required)
- latest API applied

## Links
- [TopAppBarDefaults#largeTopAppBarColors](https://developer.android.com/reference/kotlin/androidx/compose/material3/TopAppBarDefaults#largeTopAppBarColors())