### PR TITLE
Change selected icon color to match figma

### DIFF
--- a/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/component/GlassLikeBottomNavigationBar.kt
+++ b/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/component/GlassLikeBottomNavigationBar.kt
@@ -164,7 +164,7 @@ private fun BottomNavigationBarItems(
                 Icon(
                     painter = if (selected) painterResource(tab.iconOn) else painterResource(tab.iconOff),
                     contentDescription = stringResource(tab.label),
-                    tint = if (selected) MaterialTheme.colorScheme.primaryFixed else MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = modifier.size(24.dp),
                 )
             }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- The color of selected item in a bottom navigation has not match to Figma. So changed to use proper color.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/5c3e06c8-ce41-409a-9b5e-90cf0eddeb89" width="300" /> | <img src="https://github.com/user-attachments/assets/796ad835-518b-4afa-b055-5032c9df5e94" width="300" />

