### PR TITLE
Fix the ripple effect when tapping timetable items to properly follow

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
@@ -67,6 +67,7 @@ fun TimetableItemCard(
         Row(
             verticalAlignment = Alignment.Top,
             modifier = modifier
+                .clip(RoundedCornerShape(16.dp))
                 .clickable { onTimetableItemClick() }
                 .background(Color.Transparent)
                 .fillMaxWidth()


### PR DESCRIPTION
## Issue
- close #123 

## Overview (Required)
- To create a row with a ripple effect that respects RoundedCornerShape, we applied the clip modifier before the clickable modifier.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img width="61" height="81" alt="スクリーンショット 2025-08-18 1 02 04" src="https://github.com/user-attachments/assets/3f569247-a6d6-4d02-9f15-98c470f01931" /> | <img width="69" height="90" alt="スクリーンショット 2025-08-18 1 00 13" src="https://github.com/user-attachments/assets/0228d291-35df-472d-8f7b-6d8fa812b7c0" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
