### PR TITLE
Changed fixed color to MaterialTheme for SponsorScreen

### DIFF
--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
@@ -126,7 +126,7 @@ private fun LazyGridScope.sponsorsByPlanSection(
         val headerText = stringResource(headerStringResource)
         Text(
             text = headerText,
-            color = Color.Black, // FIXME: use theme color
+            color = MaterialTheme.colorScheme.primaryFixed,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(vertical = 6.dp),
         )


### PR DESCRIPTION
## Issue
- close #181 

## Overview (Required)
- Replaced default `Color.Black` to use MaterialTheme

## Tbd
- Currently this color works for both Dark/Light theme, better color scheme might be considered for light for better visibility. 


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/d9adeb78-9bae-4648-8ce8-325be29abb4d" width="300" /> | <img src="https://github.com/user-attachments/assets/408ffeef-d2e0-45a0-88f7-157952f664a0" width="300" />
