### PR TITLE
feat: Add per-app language support

### DIFF
--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <application
         android:name="io.github.droidkaigi.confsched.App"
         android:enableOnBackInvokedCallback="true"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config">
         <activity
             android:name="io.github.droidkaigi.confsched.MainActivity"
             android:exported="true"

--- a/app-android/src/main/res/xml/locales_config.xml
+++ b/app-android/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="ja" />
+</locale-config>


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/128

## Overview (Required)
- Add per-app language support.
- On Android 13+ (API 33+), the app language can be changed from **System -> Launguages -> App launguages**.
- Declare supported locales via `res/xml/locales_config.xml` and reference it with `android:localeConfig` in `AndroidManifest.xml`.
- **Why not** `androidResources.generateLocaleConfig = true`:
  - The Gradle API is **incubating/unstable** and shows a warning:  
    `setGenerateLocaleConfig(boolean) is marked unstable with @Incubating`.
  - Auto-generation can unintentionally expose locales picked up from transitive resources; a hand-curated `locales_config.xml` keeps the list **explicit and reviewable**.

## Links
- Android docs — Per-app language preferences: https://developer.android.com/guide/topics/resources/app-languages

## Screenshot (Optional if screenshot test is present or unrelated to UI)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/02233d46-e679-4e1e-a2b0-fd09e2443ffc" />
