### PR TITLE
Navigate to session detail screen when tapping session items in TimetableGrid

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -136,6 +136,7 @@ fun TimetableScreen(
                         TimetableGrid(
                             timetable = requireNotNull(uiState.timetable.timetableGridUiState[uiState.timetable.selectedDay]).timetable,
                             timeLine = null, // TODO
+                            onTimetableItemClick = onTimetableItemClick,
                             selectedDay = uiState.timetable.selectedDay,
                             contentPadding = WindowInsets.safeDrawingWithBottomNavBar.excludeTop().asPaddingValues(),
                         )

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/grid/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/grid/TimetableGrid.kt
@@ -52,6 +52,7 @@ import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.model.core.DroidKaigi2025Day
 import io.github.droidkaigi.confsched.model.sessions.Timetable
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
+import io.github.droidkaigi.confsched.model.sessions.TimetableItemId
 import io.github.droidkaigi.confsched.model.sessions.fake
 import io.github.droidkaigi.confsched.sessions.ScrolledToCurrentTimeState
 import io.github.droidkaigi.confsched.sessions.TimetableScrollState
@@ -76,6 +77,7 @@ fun TimetableGrid(
     timetable: Timetable,
     timeLine: TimeLine?,
     selectedDay: DroidKaigi2025Day,
+    onTimetableItemClick: (TimetableItemId) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
     scrolledToCurrentTimeState: ScrolledToCurrentTimeState = remember { ScrolledToCurrentTimeState() },
@@ -120,7 +122,7 @@ fun TimetableGrid(
                 items(timetable.timetableItems) { timetableItem ->
                     TimetableGridItem(
                         timetableItem = timetableItem,
-                        onTimetableItemClick = {},
+                        onTimetableItemClick = { onTimetableItemClick(it.id) },
                     )
                 }
             }
@@ -438,6 +440,7 @@ private fun TimetableGridPreview() {
                 timetable = timetable,
                 timeLine = TimeLine.now(LocalClock.current),
                 selectedDay = DroidKaigi2025Day.ConferenceDay1,
+                onTimetableItemClick = {},
             )
         }
     }


### PR DESCRIPTION
## Issue
- close #126

## Overview (Required)
- Add `onTimetableItemClick` slot to `TimetableGrid`.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/19201103-cf9d-4976-8bde-2ed97c90d57d" width="300" > | <video src="https://github.com/user-attachments/assets/401aebe9-3fa0-4d87-b331-a9b46a55873b" width="300" >
