### PR TITLE
[JVM] Implement calendar registration tap behavior in session detail

### DIFF
--- a/app-shared/src/jvmMain/kotlin/io/github/droidkaigi/confsched/JvmExternalNavController.kt
+++ b/app-shared/src/jvmMain/kotlin/io/github/droidkaigi/confsched/JvmExternalNavController.kt
@@ -3,6 +3,11 @@ package io.github.droidkaigi.confsched
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
+import java.awt.Desktop
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import kotlin.time.Instant
 
 @Composable
 actual fun rememberExternalNavController(): ExternalNavController {
@@ -15,7 +20,34 @@ class JvmExternalNavController : ExternalNavController {
     }
 
     override fun navigateToCalendarRegistration(timetableItem: TimetableItem) {
-        TODO("Not yet implemented")
+        fun Instant.toBasicISO8601String(): String {
+            return this.toString()
+                .replace("-", "")
+                .replace(":", "")
+                .replace(".", "")
+        }
+
+        fun String.encodeUtf8(): String {
+            return URLEncoder.encode(this, StandardCharsets.UTF_8.toString())
+        }
+
+        val calendarUrl = buildString {
+            append("https://calendar.google.com/calendar/r/eventedit")
+            append("?text=").append("[${timetableItem.room.name.currentLangTitle}] ${timetableItem.title.currentLangTitle}".encodeUtf8())
+            append("&dates=").append("${timetableItem.startsAt.toBasicISO8601String()}/${timetableItem.endsAt.toBasicISO8601String()}".encodeUtf8())
+            append("&details=").append(timetableItem.url.encodeUtf8())
+            append("&location=").append(timetableItem.room.name.currentLangTitle.encodeUtf8())
+        }
+
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            runCatching {
+                Desktop.getDesktop().browse(URI(calendarUrl))
+            }.onFailure { error ->
+                println("Failed to add event to calendar: $error")
+            }
+        } else {
+            println("Access to calendar not granted:")
+        }
     }
 
     override fun onShareClick(timetableItem: TimetableItem) {


### PR DESCRIPTION
## Issue
- close #164

## Overview (Required)
- Implements calendar registration using the following link template on JVM/Desktop target.
   - The format of dates and times must be **_ISO 8601_ basic format**.
   - All url query parameters must be URL encoded.

```url
https://calendar.google.com/calendar/r/eventedit
    ?action=TEMPLATE
    &dates=20230325T224500Z%2F20230326T001500Z  // ✅ Start and end dates and times
    &stz=Europe/Brussels
    &etz=Europe/Brussels
    &details=EVENT_DESCRIPTION_HERE             // ✅ description
    &location=EVENT_LOCATION_HERE               // ✅ location
    &text=EVENT_TITLE_HERE                      // ✅ title
```
> [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
> - ✅ **basic format:** `YYYYMMDDThhmmssZ` (e.g., `20250819T103000Z`)
> - ❌ extended format: `YYYY-MM-DDThh:mm:ssZ` (e.g., `2025-08-19T10:30:00Z`)

## Links
- Google Calendar API:
   https://developers.google.com/workspace/calendar/api/concepts/inviting-attendees-to-events#link-user

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/7d29f851-85de-4369-b0c9-dd7f49a2375c" width="300" > | <video src="https://github.com/user-attachments/assets/a1147ee5-8146-4f7c-98fe-97317b997ea0" width="300" >
