### PR TITLE
docs: fix detekt command to spotlessApply in CONTRIBUTING.md and CONTRIBUTING.ja.md

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -50,7 +50,7 @@ https://developer.android.com/courses/jetpack-compose/course
 コードフォーマットのコマンドは以下の通りです。Android Studioでこのドキュメントを開いて、左側の実行ボタンから実行できます。
 
 ```bash
-./gradlew detekt --auto-correct
+./gradlew spotlessApply
 ```
 
 ### 6. プルリクエストを作成する

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ https://developer.android.com/courses/jetpack-compose/course
 The command for code formatting is as follows. You can run it by opening this document in Android Studio and clicking the run button on the left:
 
 ```bash
-./gradlew detekt --auto-correct
+./gradlew spotlessApply
 ```
 
 ### 6. Create a Pull Request


### PR DESCRIPTION
## Issue
- close #196 

## Overview (Required)
- Fix outdated detekt commands in CONTRIBUTING.md and CONTRIBUTING.ja.md to use spotlessApply instead
- Identified that the display issue in CONTRIBUTING.ja.md (text incorrectly rendered as links) was caused by Chrome's automatic translation feature

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
