### PR TITLE
fix: Compose Preview crash in Feature modules by removing navigation3

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/SaveableHelper.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/SaveableHelper.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 fun rememberBooleanSaveable(initial: Boolean = false): MutableState<Boolean> {
     val saver: Saver<MutableState<Boolean>, Boolean> = Saver(
         save = { it.value },
-        restore = { mutableStateOf(it) }
+        restore = { mutableStateOf(it) },
     )
     return rememberSaveable(saver = saver) { mutableStateOf(initial) }
 }
@@ -32,7 +32,7 @@ fun rememberBooleanSaveable(initial: Boolean = false): MutableState<Boolean> {
 fun rememberIntSaveable(initial: Int = 0): MutableState<Int> {
     val saver: Saver<MutableState<Int>, Int> = Saver(
         save = { it.value },
-        restore = { mutableStateOf(it) }
+        restore = { mutableStateOf(it) },
     )
     return rememberSaveable(saver = saver) { mutableStateOf(initial) }
 }

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/SaveableHelper.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/SaveableHelper.kt
@@ -1,0 +1,38 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+/**
+ * Why this exists:
+ * - `rememberSaveable<T>` relies on a reified type parameter (T) and must be inlined.
+ * - In some call paths (e.g., context-receiver extension composables, function references,
+ *   mixed AndroidX/JB Compose toolchains, or preview classpaths), the call may not be inlined,
+ *   triggering `UnsupportedOperationException: This function has a reified type parameter...`.
+ * - Providing an explicit `Saver<MutableState<Boolean>, Boolean>` avoids the reified `autoSaver<T>()`
+ *   path entirely, while preserving process-death persistence semantics.
+ * - Prefer this helper over `rememberSaveable { mutableStateOf(false) }` when used inside extension
+ *   composables or if you hit the above crash. If persistence is not required, use `remember { ... }`.
+ * Implementation notes:
+ * - Ensure AndroidX imports (`androidx.compose.runtime.saveable.*`).
+ */
+@Composable
+fun rememberBooleanSaveable(initial: Boolean = false): MutableState<Boolean> {
+    val saver: Saver<MutableState<Boolean>, Boolean> = Saver(
+        save = { it.value },
+        restore = { mutableStateOf(it) }
+    )
+    return rememberSaveable(saver = saver) { mutableStateOf(initial) }
+}
+
+@Composable
+fun rememberIntSaveable(initial: Int = 0): MutableState<Int> {
+    val saver: Saver<MutableState<Int>, Int> = Saver(
+        save = { it.value },
+        restore = { mutableStateOf(it) }
+    )
+    return rememberSaveable(saver = saver) { mutableStateOf(initial) }
+}

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorsCounter.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorsCounter.kt
@@ -15,8 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +23,7 @@ import io.github.droidkaigi.confsched.contributors.ContributorsRes
 import io.github.droidkaigi.confsched.contributors.contributor_person
 import io.github.droidkaigi.confsched.contributors.contributor_total
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
+import io.github.droidkaigi.confsched.droidkaigiui.rememberIntSaveable
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -33,7 +32,7 @@ fun ContributorsCounter(
     totalContributors: Int,
     modifier: Modifier = Modifier,
 ) {
-    var targetValue by rememberSaveable { mutableIntStateOf(0) }
+    var targetValue by rememberIntSaveable(0)
     val animatedTotalContributor by animateIntAsState(
         targetValue = targetValue,
         animationSpec = tween(

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
@@ -1,8 +1,10 @@
 package io.github.droidkaigi.confsched.eventmap
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import io.github.droidkaigi.confsched.common.compose.EventEffect
@@ -18,7 +20,11 @@ fun eventMapScreenPresenter(
     events: PersistentList<EventMapEvent>,
     eventFlow: EventFlow<EventMapScreenEvent>,
 ) = providePresenterDefaults {
-    var selectedFloor by rememberSaveable { mutableStateOf(FloorLevel.Ground) }
+    val floorSaver: Saver<MutableState<FloorLevel>, String> = Saver(
+        save = { it.value.name },
+        restore = { mutableStateOf(FloorLevel.valueOf(it)) }
+    )
+    var selectedFloor by rememberSaveable(saver = floorSaver) { mutableStateOf(FloorLevel.Ground) }
 
     EventEffect(eventFlow) { event ->
         when (event) {

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
@@ -22,7 +22,7 @@ fun eventMapScreenPresenter(
 ) = providePresenterDefaults {
     val floorSaver: Saver<MutableState<FloorLevel>, String> = Saver(
         save = { it.value.name },
-        restore = { mutableStateOf(FloorLevel.valueOf(it)) }
+        restore = { mutableStateOf(FloorLevel.valueOf(it)) },
     )
     var selectedFloor by rememberSaveable(saver = floorSaver) { mutableStateOf(FloorLevel.Ground) }
 

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -27,6 +26,7 @@ import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.droidkaigiui.extension.roomTheme
+import io.github.droidkaigi.confsched.droidkaigiui.rememberBooleanSaveable
 import io.github.droidkaigi.confsched.model.core.Lang
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
 import io.github.droidkaigi.confsched.model.sessions.fake
@@ -60,7 +60,7 @@ private fun DescriptionSection(
     description: String,
     onLinkClick: (url: String) -> Unit,
 ) {
-    var isExpand by rememberSaveable { mutableStateOf(false) }
+    var isExpand by rememberBooleanSaveable(false)
     var isOverFlow by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.padding(8.dp)) {

--- a/gradle-conventions/src/main/kotlin/droidkaigi/convention/kmp-feature.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/droidkaigi/convention/kmp-feature.gradle.kts
@@ -43,10 +43,6 @@ kotlin {
             implementation(libs.library("lifecycleRuntimeCompose"))
         }
 
-        androidMain.dependencies {
-            implementation(libs.library("lifecycleViewmodelNavigation3"))
-        }
-
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
         }


### PR DESCRIPTION
Thanks for the awesome project!!

## Issue
- close #215

## Overview (Required)
- Compose Preview failed in Feature modules due to a version mismatch on the Android preview classpath.
- The Navigation3 line pulled Compose **runtime** to `1.9.0-SNAPSHOT` while UI/tooling stayed on `1.9.0-beta02` via the BOM, leading to `NoClassDefFoundError: SourceInformationKt`.
- **No actual Navigation3 usage was found in feature/*’ `androidMain`**, so we removed the dependency there.
<!-- - Prevention: enforce the Compose BOM and avoid Compose SNAPSHOTs on Android to prevent future drift. -->

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" />N/A | <img src="" width="300" />N/A

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
