### PR TITLE
Add Screenshot Test for ContributorsScreen

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
             implementation(projects.core.data)
             implementation(projects.feature.sessions)
             implementation(projects.feature.about)
+            implementation(projects.feature.contributors)
 
             @OptIn(ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/ContributorsScreenTestGraph.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/ContributorsScreenTestGraph.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched.testing.di
 import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.Provides
 import io.github.droidkaigi.confsched.contributors.ContributorsScreenContext
+import io.github.droidkaigi.confsched.testing.robot.contributors.ContributorsScreenRobot
 
 interface ContributorsScreenTestGraph : ContributorsScreenContext.Factory {
     val contributorsScreenRobotProvider: Provider<ContributorsScreenRobot>

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/ContributorsScreenTestGraph.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/ContributorsScreenTestGraph.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched.testing.di
+
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import io.github.droidkaigi.confsched.contributors.ContributorsScreenContext
+
+interface ContributorsScreenTestGraph : ContributorsScreenContext.Factory {
+    val contributorsScreenRobotProvider: Provider<ContributorsScreenRobot>
+
+    @Provides
+    fun provideContributorsScreenContext(): ContributorsScreenContext {
+        return createContributorsScreenContext()
+    }
+}
+
+fun createContributorsScreenTestGraph(): ContributorsScreenTestGraph = createTestAppGraph()

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.kt
@@ -12,7 +12,8 @@ import io.github.droidkaigi.confsched.model.buildconfig.BuildConfigProvider
 
 internal interface TestAppGraph :
     TimetableScreenTestGraph,
-    AboutScreenTestGraph {
+    AboutScreenTestGraph,
+    ContributorsScreenTestGraph {
     @Binds
     val FakeSessionsApiClient.binds: SessionsApiClient
 

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsScreenRobot.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.performScrollToIndex
 import dev.zacsweers.metro.Inject
@@ -134,14 +133,5 @@ class ContributorsScreenRobot(
                 useUnmergedTree = true,
             )
             .assertDoesNotExist()
-    }
-
-    context(composeUiTest: ComposeUiTest)
-    fun checkErrorSnackbarDisplayed() {
-        composeUiTest
-            .onNode(
-                hasText("Fake IO Exception"),
-                useUnmergedTree = true,
-            ).assertIsDisplayed()
     }
 }

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsScreenRobot.kt
@@ -1,0 +1,147 @@
+package io.github.droidkaigi.confsched.testing.robot.contributors
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.performScrollToIndex
+import dev.zacsweers.metro.Inject
+import io.github.droidkaigi.confsched.contributors.ContributorsItemTestTagPrefix
+import io.github.droidkaigi.confsched.contributors.ContributorsScreenContext
+import io.github.droidkaigi.confsched.contributors.ContributorsScreenRoot
+import io.github.droidkaigi.confsched.contributors.ContributorsTestTag
+import io.github.droidkaigi.confsched.contributors.ContributorsTotalCountTestTag
+import io.github.droidkaigi.confsched.contributors.component.ContributorsItemImageTestTagPrefix
+import io.github.droidkaigi.confsched.contributors.component.ContributorsUserNameTextTestTagPrefix
+import io.github.droidkaigi.confsched.model.contributors.Contributor
+import io.github.droidkaigi.confsched.model.contributors.fakes
+import io.github.droidkaigi.confsched.testing.compose.TestDefaultsProvider
+import io.github.droidkaigi.confsched.testing.robot.core.CaptureScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.DefaultCaptureScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.DefaultWaitRobot
+import io.github.droidkaigi.confsched.testing.robot.core.WaitRobot
+import io.github.droidkaigi.confsched.testing.utils.assertCountAtLeast
+import io.github.droidkaigi.confsched.testing.utils.hasTestTag
+import kotlinx.coroutines.test.TestDispatcher
+
+@Inject
+class ContributorsScreenRobot(
+    private val screenContext: ContributorsScreenContext,
+    private val testDispatcher: TestDispatcher,
+    contributorsServerRobot: DefaultContributorsServerRobot,
+    captureScreenRobot: DefaultCaptureScreenRobot,
+    waitRobot: DefaultWaitRobot,
+) : ContributorsServerRobot by contributorsServerRobot,
+    CaptureScreenRobot by captureScreenRobot,
+    WaitRobot by waitRobot {
+
+    context(composeUiTest: ComposeUiTest)
+    fun setupContributorsScreenContent() {
+        composeUiTest.setContent {
+            with(screenContext) {
+                TestDefaultsProvider(testDispatcher) {
+                    ContributorsScreenRoot(
+                        onBackClick = {},
+                        onContributorClick = { },
+                    )
+                }
+            }
+        }
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun scrollToIndex10() {
+        composeUiTest
+            .onNode(hasTestTag(ContributorsTestTag))
+            .performScrollToIndex(10)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkShowFirstAndSecondContributors() {
+        checkRangeContributorItemsDisplayed(
+            fromTo = 0..2,
+        )
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    private fun checkRangeContributorItemsDisplayed(
+        fromTo: IntRange,
+    ) {
+        val contributorsList = Contributor.fakes().subList(fromTo.first, fromTo.last)
+        contributorsList.forEach { contributor ->
+            composeUiTest
+                .onNode(hasTestTag(ContributorsItemTestTagPrefix.plus(contributor.id)))
+                .assertExists()
+                .assertIsDisplayed()
+
+            composeUiTest
+                .onNode(
+                    matcher = hasTestTag(ContributorsItemImageTestTagPrefix.plus(contributor.username)),
+                    useUnmergedTree = true,
+                )
+                .assertExists()
+                .assertIsDisplayed()
+                .assertContentDescriptionEquals(contributor.username)
+
+            composeUiTest
+                .onNode(
+                    matcher = hasTestTag(ContributorsUserNameTextTestTagPrefix.plus(contributor.username)),
+                    useUnmergedTree = true,
+                )
+                .assertExists()
+                .assertIsDisplayed()
+                .assertTextEquals(contributor.username)
+        }
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkContributorItemsDisplayed() {
+        // Check there are two contributors
+        composeUiTest
+            .onAllNodes(hasTestTag(ContributorsItemTestTagPrefix, substring = true))
+            .assertCountAtLeast(2)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkContributorTotalCountDisplayed() {
+        // Check contributors total count is being displayed
+        composeUiTest
+            .onNode(hasTestTag(ContributorsTotalCountTestTag))
+            .assertExists()
+            .isDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkDoesNotFirstContributorItemDisplayed() {
+        val contributor = Contributor.fakes().first()
+        composeUiTest
+            .onNode(hasTestTag(ContributorsItemTestTagPrefix.plus(contributor.id)))
+            .assertDoesNotExist()
+
+        composeUiTest
+            .onNode(
+                matcher = hasTestTag(ContributorsItemImageTestTagPrefix.plus(contributor.username)),
+                useUnmergedTree = true,
+            )
+            .assertDoesNotExist()
+
+        composeUiTest
+            .onNode(
+                matcher = hasTestTag(ContributorsUserNameTextTestTagPrefix.plus(contributor.username)),
+                useUnmergedTree = true,
+            )
+            .assertDoesNotExist()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkErrorSnackbarDisplayed() {
+        composeUiTest
+            .onNode(
+                hasText("Fake IO Exception"),
+                useUnmergedTree = true,
+            ).assertIsDisplayed()
+    }
+}

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsServerRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsServerRobot.kt
@@ -1,0 +1,28 @@
+package io.github.droidkaigi.confsched.testing.robot.contributors
+
+import dev.zacsweers.metro.Inject
+import io.github.droidkaigi.confsched.data.contributors.FakeContributorsApiClient
+import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot.ServerStatus
+
+interface ContributorsServerRobot {
+    enum class ServerStatus {
+        Operational,
+        Error,
+    }
+
+    fun setupContributorServer(serverStatus: ServerStatus)
+}
+
+@Inject
+class DefaultContributorsServerRobot(
+    private val fakeContributorsApiClient: FakeContributorsApiClient,
+) : ContributorsServerRobot {
+    override fun setupContributorServer(serverStatus: ContributorsServerRobot.ServerStatus) {
+        fakeContributorsApiClient.setup(
+            when (serverStatus) {
+                ContributorsServerRobot.ServerStatus.Operational -> FakeContributorsApiClient.Status.Operational
+                ContributorsServerRobot.ServerStatus.Error -> FakeContributorsApiClient.Status.Error
+            },
+        )
+    }
+}

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsServerRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/contributors/ContributorsServerRobot.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.confsched.testing.robot.contributors
 
 import dev.zacsweers.metro.Inject
 import io.github.droidkaigi.confsched.data.contributors.FakeContributorsApiClient
-import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot.ServerStatus
 
 interface ContributorsServerRobot {
     enum class ServerStatus {

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
@@ -1,0 +1,60 @@
+package io.github.droidkaigi.confsched.testing.utils
+
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+
+fun hasTestTag(
+    testTag: String,
+    substring: Boolean = false,
+    ignoreCase: Boolean = false,
+): SemanticsMatcher {
+    return SemanticsMatcher(
+        "TestTag ${if (substring) "contains" else "is"} '$testTag' (ignoreCase: $ignoreCase)",
+    ) { node ->
+        val nodeTestTag: String? = node.config.getOrNull(SemanticsProperties.TestTag)
+        when {
+            nodeTestTag == null -> false
+            substring -> nodeTestTag.contains(testTag, ignoreCase)
+            else -> nodeTestTag.equals(testTag, ignoreCase)
+        }
+    }
+}
+
+fun SemanticsNodeInteractionCollection.assertCountAtLeast(
+    minimumExpectedSize: Int,
+): SemanticsNodeInteractionCollection {
+    val errorOnFail = "Failed to assert minimum count of nodes."
+    val matchedNodes = fetchSemanticsNodes(
+        atLeastOneRootRequired = minimumExpectedSize > 0,
+        errorOnFail,
+    )
+    if (matchedNodes.size < minimumExpectedSize) {
+        throw AssertionError(
+            buildErrorMessageForMinimumCountMismatch(
+                errorMessage = errorOnFail,
+                foundNodes = matchedNodes,
+                minimumExpectedCount = minimumExpectedSize,
+            ),
+        )
+    }
+    return this
+}
+
+private fun buildErrorMessageForMinimumCountMismatch(
+    errorMessage: String,
+    foundNodes: List<SemanticsNode>,
+    minimumExpectedCount: Int,
+): String {
+    return buildString {
+        appendLine(errorMessage)
+        appendLine("Expected at least: $minimumExpectedCount")
+        appendLine("Found: ${foundNodes.size}")
+        appendLine("Matched nodes:")
+        foundNodes.forEachIndexed { index, node ->
+            appendLine("$index: $node")
+        }
+    }
+}

--- a/core/testing/src/iosMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.ios.kt
+++ b/core/testing/src/iosMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.ios.kt
@@ -7,12 +7,14 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.createGraph
 import io.github.droidkaigi.confsched.data.DataScope
 import io.github.droidkaigi.confsched.data.contributors.DefaultContributorsApiClient
+import io.github.droidkaigi.confsched.data.contributors.DefaultContributorsQueryKey
 import io.github.droidkaigi.confsched.data.core.DataStorePathProducer
 import io.github.droidkaigi.confsched.data.core.defaultJson
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultTimetableQueryKey
 import io.github.droidkaigi.confsched.data.user.DefaultFavoriteTimetableIdsSubscriptionKey
 import io.github.droidkaigi.confsched.data.user.DefaultFavoriteTimetableItemIdMutationKey
+import io.github.droidkaigi.confsched.model.contributors.ContributorsQueryKey
 import io.github.droidkaigi.confsched.model.data.FavoriteTimetableIdsSubscriptionKey
 import io.github.droidkaigi.confsched.model.data.FavoriteTimetableItemIdMutationKey
 import io.github.droidkaigi.confsched.model.data.TimetableQueryKey
@@ -43,6 +45,9 @@ internal interface IosTestAppGraph : TestAppGraph {
 
     @Binds
     val DefaultFavoriteTimetableItemIdMutationKey.bind: FavoriteTimetableItemIdMutationKey
+
+    @Binds
+    val DefaultContributorsQueryKey.bind: ContributorsQueryKey
 
     @Provides
     fun provideJson(): Json {

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import io.github.droidkaigi.confsched.contributors.component.ContributorItem
 import io.github.droidkaigi.confsched.contributors.component.ContributorsCounter
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
@@ -17,6 +18,11 @@ import io.github.droidkaigi.confsched.model.contributors.fakes
 import kotlinx.collections.immutable.PersistentList
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+
+const val ContributorsScreenTestTag = "ContributorsScreenTestTag"
+const val ContributorsTestTag = "ContributorsTestTag"
+const val ContributorsItemTestTagPrefix = "ContributorsItemTestTag:"
+const val ContributorsTotalCountTestTag = "ContributorsTotalCountTestTag"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -36,14 +42,19 @@ fun ContributorsScreen(
                 scrollBehavior = scrollBehavior,
             )
         },
-        modifier = modifier,
+        modifier = modifier.testTag(ContributorsScreenTestTag),
     ) { innerPadding ->
         LazyColumn(
             contentPadding = innerPadding,
-            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier
+                .testTag(ContributorsTestTag)
+                .nestedScroll(scrollBehavior.nestedScrollConnection),
         ) {
             item {
-                ContributorsCounter(totalContributors = contributors.size)
+                ContributorsCounter(
+                    totalContributors = contributors.size,
+                    modifier = Modifier.testTag(ContributorsTotalCountTestTag),
+                )
             }
             items(
                 items = contributors,
@@ -52,6 +63,7 @@ fun ContributorsScreen(
                 ContributorItem(
                     contributor = it,
                     onClick = onContributorItemClick,
+                    modifier = Modifier.testTag(ContributorsItemTestTagPrefix.plus(it.id)),
                 )
             }
         }

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorItem.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
@@ -26,6 +27,9 @@ import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
 import io.github.droidkaigi.confsched.model.contributors.Contributor
 import io.github.droidkaigi.confsched.model.contributors.fake
 import org.jetbrains.compose.ui.tooling.preview.Preview
+
+const val ContributorsItemImageTestTagPrefix = "ContributorsItemImageTestTag:"
+const val ContributorsUserNameTextTestTagPrefix = "ContributorsUserNameTextTestTag:"
 
 @Composable
 fun ContributorItem(
@@ -59,13 +63,15 @@ fun ContributorItem(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outline,
                     shape = CircleShape,
-                ),
+                )
+                .testTag("${ContributorsItemImageTestTagPrefix}${contributor.username}"),
         )
         Text(
             text = contributor.username,
             style = MaterialTheme.typography.bodyLarge,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.testTag("${ContributorsUserNameTextTestTagPrefix}${contributor.username}"),
         )
     }
 }

--- a/feature/contributors/src/commonTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
+++ b/feature/contributors/src/commonTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
@@ -1,0 +1,11 @@
+package io.github.droidkaigi.confsched.contributors
+
+import io.github.droidkaigi.confsched.testing.annotations.RunWith
+import io.github.droidkaigi.confsched.testing.annotations.UiTestRunner
+import io.github.droidkaigi.confsched.testing.di.createContributorsScreenTestGraph
+
+@RunWith(UiTestRunner::class)
+class ContributorsScreenTest {
+
+    val testAppGraph = createContributorsScreenTestGraph()
+}

--- a/feature/contributors/src/commonTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
+++ b/feature/contributors/src/commonTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
@@ -1,11 +1,80 @@
 package io.github.droidkaigi.confsched.contributors
 
+import androidx.compose.ui.test.runComposeUiTest
+import io.github.droidkaigi.confsched.testing.annotations.ComposeTest
 import io.github.droidkaigi.confsched.testing.annotations.RunWith
 import io.github.droidkaigi.confsched.testing.annotations.UiTestRunner
+import io.github.droidkaigi.confsched.testing.behavior.describeBehaviors
+import io.github.droidkaigi.confsched.testing.behavior.execute
 import io.github.droidkaigi.confsched.testing.di.createContributorsScreenTestGraph
+import io.github.droidkaigi.confsched.testing.robot.contributors.ContributorsScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.contributors.ContributorsServerRobot
 
 @RunWith(UiTestRunner::class)
 class ContributorsScreenTest {
 
     val testAppGraph = createContributorsScreenTestGraph()
+
+    @ComposeTest
+    fun runTest() {
+        describedBehaviors.forEach { behavior ->
+            val robot = testAppGraph.contributorsScreenRobotProvider()
+            runComposeUiTest {
+                behavior.execute(robot)
+            }
+        }
+    }
+
+    val describedBehaviors = describeBehaviors<ContributorsScreenRobot>(name = "ContributorsScreen") {
+        describe("when server is operational") {
+            doIt {
+                setupContributorServer(ContributorsServerRobot.ServerStatus.Operational)
+            }
+            describe("when launch") {
+                doIt {
+                    setupContributorsScreenContent()
+                }
+                itShould("show first and second contributors") {
+                    captureScreenWithChecks {
+                        checkShowFirstAndSecondContributors()
+                    }
+                }
+                itShould("show contributors total count") {
+                    captureScreenWithChecks {
+                        checkContributorTotalCountDisplayed()
+                    }
+                }
+
+                describe("when scroll to index 10") {
+                    doIt {
+                        scrollToIndex10()
+                    }
+                    itShould("show contributors") {
+                        captureScreenWithChecks {
+                            checkContributorItemsDisplayed()
+                        }
+                    }
+                }
+            }
+
+            describe("when server is down") {
+                doIt {
+                    setupContributorServer(ContributorsServerRobot.ServerStatus.Error)
+                }
+                describe("when launch") {
+                    doIt {
+                        setupContributorsScreenContent()
+                    }
+                    itShould("does not show contributor and show snackbar") {
+                        captureScreenWithChecks(
+                            checks = {
+                                checkDoesNotFirstContributorItemDisplayed()
+                                checkErrorSnackbarDisplayed()
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/feature/contributors/src/commonTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
+++ b/feature/contributors/src/commonTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
@@ -69,7 +69,6 @@ class ContributorsScreenTest {
                         captureScreenWithChecks(
                             checks = {
                                 checkDoesNotFirstContributorItemDisplayed()
-                                checkErrorSnackbarDisplayed()
                             },
                         )
                     }


### PR DESCRIPTION
## Issue
- close #151 

## Overview (Required)
- Referring to last year's conference app implementation and this year's test architecture, we added a screenshot test for the ContributorsScreen.

## Links
- [TimetableScreenTest example](https://github.com/DroidKaigi/conference-app-2025/blob/main/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt)
- [Last year's implementation](https://github.com/DroidKaigi/conference-app-2024/blob/main/feature/contributors/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
