### PR TITLE
fix: correct timetable toggle icon and description mapping

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
@@ -42,12 +42,12 @@ fun TimetableTopAppBar(
             }
             IconButton(onClick = onUiTypeChangeClick) {
                 val iconRes = when (timetableUiType) {
-                    TimetableUiType.List -> SessionsRes.drawable.ic_view_timeline
-                    TimetableUiType.Grid -> SessionsRes.drawable.ic_view_grid
+                    TimetableUiType.List -> SessionsRes.drawable.ic_view_grid
+                    TimetableUiType.Grid -> SessionsRes.drawable.ic_view_timeline
                 }
                 val descriptionRes = when (timetableUiType) {
-                    TimetableUiType.List -> SessionsRes.string.timeline_view
-                    TimetableUiType.Grid -> SessionsRes.string.grid_view
+                    TimetableUiType.List -> SessionsRes.string.grid_view
+                    TimetableUiType.Grid -> SessionsRes.string.timeline_view
                 }
                 Icon(
                     painter = painterResource(iconRes),


### PR DESCRIPTION
Switch icon and description mapping to show the view mode that will be activated when clicked, not the current mode.
- When in List mode, show grid icon to indicate switching to Grid view
- When in Grid mode, show timeline icon to indicate switching to List view

🤖 Generated with [Claude Code](https://claude.ai/code)

## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/234

## Overview (Required)
- Correct timetable view toggle icon to display the mode user will switch to

## Links
- [Figma Link](https://www.figma.com/design/1YjyMBNVLEGcHP4W7UNzDE/DroidKaigi-2025-App-UI?node-id=54795-26746&p=f&t=zlr0D81bAK84U53h-0)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/7269944d-0597-4dca-8067-2fc3556cd772" width="300" /> | <img src="https://github.com/user-attachments/assets/bc34c490-1758-495b-acf9-d6b52c388cc5" width="300" />

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/06b18012-66ea-4fe0-82a5-34877369d4b4" width="300" /> | <img src="https://github.com/user-attachments/assets/88f8e316-903e-458b-865c-7d8ea1ee398b" width="300" />

## Movie (Optional)
https://github.com/user-attachments/assets/741fac23-99e9-4ca5-9034-77d6988079c5

