### PR TITLE
refactor: replace painterResource with vectorResource for vector icons

### DIFF
--- a/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/component/GlassLikeBottomNavigationBar.kt
+++ b/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/component/GlassLikeBottomNavigationBar.kt
@@ -48,8 +48,8 @@ import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.droidkaigi.confsched.common.graphics.isBlurSupported
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -162,7 +162,7 @@ private fun BottomNavigationBarItems(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    painter = if (selected) painterResource(tab.iconOn) else painterResource(tab.iconOff),
+                    imageVector = if (selected) vectorResource(tab.iconOn) else vectorResource(tab.iconOff),
                     contentDescription = stringResource(tab.label),
                     tint = if (selected) MaterialTheme.colorScheme.primaryFixed else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = modifier.size(24.dp),

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapItem.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapItem.kt
@@ -33,8 +33,8 @@ import io.github.droidkaigi.confsched.eventmap.read_more
 import io.github.droidkaigi.confsched.model.eventmap.EventMapEvent
 import io.github.droidkaigi.confsched.model.eventmap.fakes
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -127,7 +127,7 @@ private fun ToolTip(
     ) {
         roomIcon?.let {
             Icon(
-                painter = painterResource(it),
+                imageVector = vectorResource(it),
                 contentDescription = null,
                 tint = color,
                 modifier = Modifier.size(12.dp),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
@@ -19,8 +19,8 @@ import io.github.droidkaigi.confsched.sessions.ic_view_timeline
 import io.github.droidkaigi.confsched.sessions.search
 import io.github.droidkaigi.confsched.sessions.timeline_view
 import io.github.droidkaigi.confsched.sessions.timetable
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -50,7 +50,7 @@ fun TimetableTopAppBar(
                     TimetableUiType.Grid -> SessionsRes.string.timeline_view
                 }
                 Icon(
-                    painter = painterResource(iconRes),
+                    imageVector = vectorResource(iconRes),
                     contentDescription = stringResource(descriptionRes),
                 )
             }


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/239

## Overview (Required)
Replace painterResource with vectorResource for better recomposition performance:                                                                                                                                                                                                                                                               
- TimetableTopAppBar: Toggle icons (ic_view_grid, ic_view_timeline)                                                                                                        
- EventMapItem: Room icons in ToolTip component(ic_square, ic_circle, ic_diamond, ic_rhombus, ic_triangle)                                                                                                             
- GlassLikeBottomNavigationBar: Navigation tab icons (iconOn, iconOff)                                                                                                     
                                                                                                                                                                          
Benefits:                                                                                                                                                                  
- Eliminates unnecessary recompositions through caching                                                                                                                    
- Reduces Painter object creation overhead                                                                                                                                 
- Improves performance for frequently recomposed UI elements"   

## Links
- https://developer.android.com/develop/ui/compose/graphics/images/compare
- https://developer.android.com/develop/ui/compose/graphics/images/optimization
- https://www.droidcon.com/2024/10/01/imagevector-vs-painterresources-under-the-hood/

## Screenshot (Optional if screenshot test is present or unrelated to UI)
I wanted to use Layout Inspector to numerically demonstrate recomposition improvements and upload screenshots, but I couldn't run Layout Inspector properly due to the following error in latest version's Android Studio.

`Please specify -Dappinspection.use.snapshot.jar=true as a custom VM property when using snapshot jars.`

<img src="https://github.com/user-attachments/assets/fd74b1df-59c8-4c36-bd9c-ee99e4453e0d" width="500" />

<img src="https://github.com/user-attachments/assets/815d1ab6-06c2-480c-a9b6-9fc6c02aefb4" width="400" />
