### PR TITLE
fix: speaker name text overflow in TimetableGridItem

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableGridItem.kt
@@ -180,6 +180,12 @@ private fun TimetableSpeaker(
         Text(
             text = speaker.name,
             style = MaterialTheme.typography.titleSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            autoSize = TextAutoSize.StepBased(
+                minFontSize = TimetableGridItemDefaults.minTitleFontSize,
+                maxFontSize = TimetableGridItemDefaults.maxTitleFontSize,
+            ),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier
                 .align(Alignment.CenterVertically)


### PR DESCRIPTION
## Issue
- close #242

## Overview (Required)
- The speaker's name text in the TimetableGridItem now has a maxLines of 1, uses TextOverflow.Ellipsis for overflow, and applies TextAutoSize.StepBased for dynamic font sizing. This ensures the speaker's name fits within the available space without truncation or overlapping.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a2b11d61-69c9-4317-bce1-5d58e1d7c9f7" width="300" /> | <img src="https://github.com/user-attachments/assets/ca1fd1a5-9d98-4972-8fa6-6a3e8ce16390" width="300" />



## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
