### PR TITLE
feat: support multiple lines for TimetableItemTag

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -84,8 +85,9 @@ fun TimetableItemCard(
                     .weight(1f)
                     .padding(top = TimetableItemCardDefaults.rippleTopPadding),
             ) {
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     TimetableItemRoomTag(
                         icon = timetableItem.room.icon,


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/241

## Overview (Required)
- Replace Row with FlowRow layout for timetable item tags to allow tags to wrap to multiple lines when they overflow horizontally.

## Links
- https://developer.android.com/develop/ui/compose/layouts/flow?hl=ko

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/9133589f-ace6-4700-b357-6f56e134dd20" width="300" /> | <img src="https://github.com/user-attachments/assets/fec1d5fa-8231-4e69-b52f-ad8976bd1acf" width="300" />
