### PR TITLE
feat: uniform systemBarStyle in light/dark mode for Android App

### DIFF
--- a/app-android/src/main/kotlin/io/github/droidkaigi/confsched/MainActivity.kt
+++ b/app-android/src/main/kotlin/io/github/droidkaigi/confsched/MainActivity.kt
@@ -11,7 +11,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(scrim = TRANSPARENT),
-            navigationBarStyle = SystemBarStyle.dark(scrim = TRANSPARENT)
+            navigationBarStyle = SystemBarStyle.dark(scrim = TRANSPARENT),
         )
         super.onCreate(savedInstanceState)
 

--- a/app-android/src/main/kotlin/io/github/droidkaigi/confsched/MainActivity.kt
+++ b/app-android/src/main/kotlin/io/github/droidkaigi/confsched/MainActivity.kt
@@ -1,13 +1,18 @@
 package io.github.droidkaigi.confsched
 
+import android.graphics.Color.TRANSPARENT
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(scrim = TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.dark(scrim = TRANSPARENT)
+        )
         super.onCreate(savedInstanceState)
 
         with(appGraph) {


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/249

## Overview (Required)
- Unified the system bar background and icon colors for both light and dark modes to match the dark mode styling, providing users with a uniform UI/UX experience throughout the app.

## Links
- https://github.com/androidx/androidx/blob/androidx-main/activity/activity/src/main/java/androidx/activity/EdgeToEdge.kt

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/838d9440-f663-4ea7-a70f-a206e5a54e9c" width="300" /> | <img src="https://github.com/user-attachments/assets/5a128421-5828-499b-b0ed-263c6b623048" width="300" />

## Movie (Optional)
https://github.com/user-attachments/assets/f0772048-d9e7-48bb-8205-710961143aac
