### PR TITLE
Update iOS setup instructions

### DIFF
--- a/app-ios/CLAUDE.md
+++ b/app-ios/CLAUDE.md
@@ -11,7 +11,9 @@ This is the iOS app for DroidKaigi 2025 conference. For general project informat
 ### Quick Setup
 ```bash
 # Install nest (if not already installed)
-brew install mtj0928/tap/nest
+curl -s https://raw.githubusercontent.com/mtj0928/nest/main/Scripts/install.sh | bash
+# Add nest to PATH (if not already done)
+export PATH="$PATH:~/.nest/bin"
 
 # Initial setup (installs SwiftLint via nest)
 make setup

--- a/app-ios/Makefile
+++ b/app-ios/Makefile
@@ -20,7 +20,7 @@ setup: ## Initial setup for the project
 			echo "Please install nest from: https://github.com/mtj0928/nest"; \
 			echo ""; \
 			echo "Installation options:"; \
-			echo "  - Script: curl -s https://raw.githubusercontent.com/mtj0928/nest/main/Scripts/install.sh | bash" (Don't forget to add ~/.nest/bin to PATH); \
+			echo "  - Script: curl -s https://raw.githubusercontent.com/mtj0928/nest/main/Scripts/install.sh | bash (Don't forget to add ~/.nest/bin to PATH)"; \
 			echo "  - Manual: Download from https://github.com/mtj0928/nest/releases"; \
 			exit 1; \
 		fi; \

--- a/app-ios/Makefile
+++ b/app-ios/Makefile
@@ -20,7 +20,7 @@ setup: ## Initial setup for the project
 			echo "Please install nest from: https://github.com/mtj0928/nest"; \
 			echo ""; \
 			echo "Installation options:"; \
-			echo "  - Homebrew: brew install mtj0928/tap/nest"; \
+			echo "  - Script: curl -s https://raw.githubusercontent.com/mtj0928/nest/main/Scripts/install.sh | bash" (Don't forget to add ~/.nest/bin to PATH); \
 			echo "  - Manual: Download from https://github.com/mtj0928/nest/releases"; \
 			exit 1; \
 		fi; \

--- a/app-ios/Makefile
+++ b/app-ios/Makefile
@@ -29,7 +29,6 @@ setup: ## Initial setup for the project
 	fi
 	@cd Core && swift package resolve
 	@cd Native && swift package resolve
-	@swift package resolve
 	@echo "Setup complete!"
 
 .PHONY: build

--- a/app-ios/README.md
+++ b/app-ios/README.md
@@ -145,21 +145,25 @@ graph LR
 1. Clone the repository:
 ```bash
 git clone https://github.com/DroidKaigi/conference-app-2025.git
-cd conference-app-2025/app-ios
 ```
 
-2. Setup the project:
+2. Assemble the shared KMP framework:
 ```bash
-make setup
+./gradlew app-shared:assembleSharedXCFramework
+```
+
+3. Setup the project:
+```bash
+cd app-ios && make setup
 ```
 Note: This installs SwiftLint via nest. Make sure nest is installed first (`brew install mtj0928/tap/nest`).
 
-3. Open the project:
+4. Open the project:
 ```bash
 open DroidKaigi2025.xcodeproj
 ```
 
-4. Build and run:
+5. Build and run:
    - Select the `DroidKaigi2025` scheme
    - Choose your target device/simulator
    - Press `Cmd+R` to build and run

--- a/app-ios/README.md
+++ b/app-ios/README.md
@@ -156,7 +156,7 @@ git clone https://github.com/DroidKaigi/conference-app-2025.git
 ```bash
 cd app-ios && make setup
 ```
-Note: This installs SwiftLint via nest. Make sure nest is installed first (`brew install mtj0928/tap/nest`).
+Note: This installs SwiftLint via nest. Make sure nest is installed first (`curl -s https://raw.githubusercontent.com/mtj0928/nest/main/Scripts/install.sh | bash`) and confirm `~/.nest/bin` is added to PATH.
 
 4. Open the project:
 ```bash


### PR DESCRIPTION
## Issue
- close #251

## Overview (Required)
- Add the required setup steps to README.md.
-  Remove the command in the Makefile that were causing setup errors.
- Change the nest installation method from `brew install mtj0928/tap/nest` to use the officially documented approach
    - The original approch caused `fatal: repository 'https://github.com/mtj0928/homebrew-tap/' not found`.

