### PR TITLE
Make the error fallback screen scrollable

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/architecture/DefaultErrorFallbackContent.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/architecture/DefaultErrorFallbackContent.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -32,6 +34,7 @@ fun DefaultErrorFallbackContent(modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .testTag(DefaultErrorFallbackContentTestTag),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(35.dp, Alignment.CenterVertically),


### PR DESCRIPTION
## Issue
- close #191

## Overview (Required)
The fallback error screen doesn't work properly when screen size is too small or when the device is rotated to landscape mode. As the screen is not scrollable, all contents (retry button for example) is not being displayed. For now, the retry button cannot be seen and thus cannot be pressed.
This PR fixes the issue and make the screen scrollable so that all the contents be visible and interactable to the user.

## Video
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/b5c17f68-7bda-48b1-9db0-09269499a603" width="300" > | <video src="https://github.com/user-attachments/assets/b5b17a9f-12f4-49ce-8c24-5d7049afee7e" width="300" >
