### PR TITLE
fix app-shared module so that Android Studio's completion features work properly

### DIFF
--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/LicensesScreenRoot.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/LicensesScreenRoot.kt
@@ -25,7 +25,7 @@ fun LicensesScreenRoot(
             windowInsets = WindowInsets.safeDrawing,
         ),
     ) { licensesJson ->
-        val libraries by rememberLibraries(licensesJson)
+        val libraries by rememberLibraries { licensesJson }
         LicensesScreen(
             libraries = libraries,
             onBackClick = onBackClick,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,11 @@ molecule = "2.1.0"
 
 navigationCompose = "2.9.0-beta04"
 
-aboutLibraries = "12.2.4"
+# >= 12.1.2 triggers a Kotlin MPP model failure during Gradle sync
+# java.lang.IllegalStateException:
+# The value for task ':app-shared:findLibraries' property 'offlineMode'
+# is final and cannot be changed any further.
+aboutLibraries = "12.1.1"
 
 filekit = "0.10.0"
 


### PR DESCRIPTION
 downgrading aboutLibraries to 12.1.1

## Issue
- close #253

## Overview (Required)
- the AboutLibraries Gradle plugin v12.2.4 was crashing during IDE Gradle sync while building the KMP model (task :app-shared:findLibraries), throwing “offlineMode is final and cannot be changed.” Because of that, Android Studio only indexed androidMain and code completion broke.
- Workaround applied: I pinned the plugin in app-shared to v12.1.1. After that, Gradle sync succeeded and Android Studio recognized androidJvmMain again (no more “Kotlin not configured” / unresolved references). 
- I’m seeing similar error reports starting from 12.1.2+, and downgrading to 12.1.1 consistently fixes it here. Please take a look.

- 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
