### PR TITLE
feat: implemented bookmark state

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -56,7 +56,9 @@ fun SearchScreen(
                         onBookmarkClick = { sessionId ->
                             onEvent(SearchScreenEvent.Bookmark(sessionId.value))
                         },
-                        isBookmarked = { false }, // TODO: Pass actual bookmarked state
+                        isBookmarked = { timetableItemId ->
+                            uiState.bookmarks.contains(timetableItemId)
+                        },
                         highlightWord = uiState.searchQuery,
                     )
                 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenContext.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenContext.kt
@@ -5,12 +5,14 @@ import dev.zacsweers.metro.ContributesGraphExtension
 import io.github.droidkaigi.confsched.common.scope.SearchScope
 import io.github.droidkaigi.confsched.context.ScreenContext
 import io.github.droidkaigi.confsched.model.data.FavoriteTimetableIdsSubscriptionKey
+import io.github.droidkaigi.confsched.model.data.FavoriteTimetableItemIdMutationKey
 import io.github.droidkaigi.confsched.model.data.TimetableQueryKey
 
 @ContributesGraphExtension(SearchScope::class)
 interface SearchScreenContext : ScreenContext {
     val timetableQueryKey: TimetableQueryKey
     val favoriteTimetableIdsSubscriptionKey: FavoriteTimetableIdsSubscriptionKey
+    val favoriteTimetableItemIdMutationKey: FavoriteTimetableItemIdMutationKey
 
     @ContributesGraphExtension.Factory(AppScope::class)
     fun interface Factory {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -12,10 +12,12 @@ import io.github.droidkaigi.confsched.model.core.Filters
 import io.github.droidkaigi.confsched.model.core.Lang
 import io.github.droidkaigi.confsched.model.sessions.Timetable
 import io.github.droidkaigi.confsched.model.sessions.TimetableCategory
+import io.github.droidkaigi.confsched.model.sessions.TimetableItemId
 import io.github.droidkaigi.confsched.model.sessions.TimetableSessionType
 import io.github.takahirom.rin.rememberRetained
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentMap
+import soil.query.compose.rememberMutation
 
 @Composable
 context(screenContext: SearchScreenContext)
@@ -28,6 +30,8 @@ fun searchScreenPresenter(
     var selectedCategory by rememberRetained { mutableStateOf<TimetableCategory?>(null) }
     var selectedSessionType by rememberRetained { mutableStateOf<TimetableSessionType?>(null) }
     var selectedLanguage by rememberRetained { mutableStateOf<Lang?>(null) }
+    var selectedBookmarks by rememberRetained { mutableStateOf(timetable.bookmarks) }
+    val favoriteTimetableItemIdMutation = rememberMutation(screenContext.favoriteTimetableItemIdMutationKey)
 
     EventEffect(eventFlow) { event ->
         when (event) {
@@ -49,7 +53,14 @@ fun searchScreenPresenter(
                 }
             }
             is SearchScreenEvent.Bookmark -> {
-                // TODO: Implement bookmark mutation issue#188
+                val targetId = TimetableItemId(event.sessionId)
+                val newBookmarks = if (selectedBookmarks.contains(targetId)) {
+                    selectedBookmarks.remove(targetId)
+                } else {
+                    selectedBookmarks.add(targetId)
+                }
+                selectedBookmarks = newBookmarks
+                favoriteTimetableItemIdMutation.mutate(targetId)
             }
             SearchScreenEvent.ClearFilters -> {
                 selectedDay = null
@@ -108,5 +119,6 @@ fun searchScreenPresenter(
             availableLanguages = listOf(Lang.JAPANESE, Lang.ENGLISH),
         ),
         hasSearchCriteria = hasSearchCriteria,
+        bookmarks = selectedBookmarks,
     )
 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -53,11 +53,6 @@ fun searchScreenPresenter(
             }
             is SearchScreenEvent.Bookmark -> {
                 val targetId = TimetableItemId(event.sessionId)
-                if (timetable.bookmarks.contains(targetId)) {
-                    timetable.bookmarks.remove(targetId)
-                } else {
-                    timetable.bookmarks.add(targetId)
-                }
                 favoriteTimetableItemIdMutation.mutate(targetId)
             }
             SearchScreenEvent.ClearFilters -> {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -30,7 +30,6 @@ fun searchScreenPresenter(
     var selectedCategory by rememberRetained { mutableStateOf<TimetableCategory?>(null) }
     var selectedSessionType by rememberRetained { mutableStateOf<TimetableSessionType?>(null) }
     var selectedLanguage by rememberRetained { mutableStateOf<Lang?>(null) }
-    var selectedBookmarks by rememberRetained { mutableStateOf(timetable.bookmarks) }
     val favoriteTimetableItemIdMutation = rememberMutation(screenContext.favoriteTimetableItemIdMutationKey)
 
     EventEffect(eventFlow) { event ->
@@ -54,12 +53,11 @@ fun searchScreenPresenter(
             }
             is SearchScreenEvent.Bookmark -> {
                 val targetId = TimetableItemId(event.sessionId)
-                val newBookmarks = if (selectedBookmarks.contains(targetId)) {
-                    selectedBookmarks.remove(targetId)
+                if (timetable.bookmarks.contains(targetId)) {
+                    timetable.bookmarks.remove(targetId)
                 } else {
-                    selectedBookmarks.add(targetId)
+                    timetable.bookmarks.add(targetId)
                 }
-                selectedBookmarks = newBookmarks
                 favoriteTimetableItemIdMutation.mutate(targetId)
             }
             SearchScreenEvent.ClearFilters -> {
@@ -119,6 +117,6 @@ fun searchScreenPresenter(
             availableLanguages = listOf(Lang.JAPANESE, Lang.ENGLISH),
         ),
         hasSearchCriteria = hasSearchCriteria,
-        bookmarks = selectedBookmarks,
+        bookmarks = timetable.bookmarks,
     )
 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenUiState.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenUiState.kt
@@ -5,9 +5,12 @@ import io.github.droidkaigi.confsched.model.core.DroidKaigi2025Day
 import io.github.droidkaigi.confsched.model.core.Lang
 import io.github.droidkaigi.confsched.model.sessions.TimetableCategory
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
+import io.github.droidkaigi.confsched.model.sessions.TimetableItemId
 import io.github.droidkaigi.confsched.model.sessions.TimetableSessionType
 import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.datetime.LocalTime
 
 data class SearchScreenUiState(
@@ -15,6 +18,7 @@ data class SearchScreenUiState(
     val groupedSessions: PersistentMap<TimeSlot, List<TimetableItem>> = persistentMapOf(),
     val availableFilters: Filters = Filters.EMPTY,
     val hasSearchCriteria: Boolean = false,
+    val bookmarks: PersistentSet<TimetableItemId> = persistentSetOf(),
 ) {
     data class TimeSlot(
         val startTime: LocalTime,


### PR DESCRIPTION
## Issue
- close #188 

## Overview (Required)
- Introduced a `selectedBookmarks` state variable in searchScreenPresenter to manage the live state of bookmarks.
- Implemented an update approach for bookmarking, where the UI is updated instantly to give the user immediate feedback.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | ![untitled-ezgif com-resize](https://github.com/user-attachments/assets/9bc1b0ef-ebf4-4609-8cba-38d9e2ee7bff)


