### PR TITLE
【TimetableItemDetailScreen】 Screen doesn't extend behind navigation bar in 3-button navigation

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.sessions
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -51,6 +52,7 @@ fun TimetableItemDetailScreen(
                     onWatchVideoClick = onLinkClick,
                 )
             },
+            contentWindowInsets = WindowInsets(),
             modifier = modifier,
         ) { innerPadding ->
             LazyColumn(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -1,8 +1,10 @@
 package io.github.droidkaigi.confsched.sessions
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeGestures
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -50,6 +52,7 @@ fun TimetableItemDetailScreen(
                     onShareClick = { onShareClick(uiState.timetableItem) },
                     onViewSlideClick = onLinkClick,
                     onWatchVideoClick = onLinkClick,
+                    modifier = Modifier.padding(bottom = WindowInsets.safeGestures.asPaddingValues().calculateBottomPadding()),
                 )
             },
             contentWindowInsets = WindowInsets(),


### PR DESCRIPTION
## Issue
- close #266

## Overview
When displaying TimetableItemDetailScreen with 3-button navigation, the screen content doesn't extend behind the navigation bar. This PR solves this problem so that screen contents can be extended even behind the nav bar.
This PR also fixes the padding for FAB button of favorite so that it doesn't conflict with nav bar and can be seen properly above navigation bar.

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/4a994233-44ec-4ea6-837c-53f201f5dafa" width="300" /> | <img src="https://github.com/user-attachments/assets/244bbf66-5495-48a8-91bd-d76db22ab5b9" width="300" />
