### PR TITLE
fix: App crashes on simultaneous TopAppBar and system navigation back button press

### DIFF
--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -20,7 +20,7 @@ import io.github.droidkaigi.confsched.naventry.profileNavEntry
 import io.github.droidkaigi.confsched.naventry.sessionEntries
 import io.github.droidkaigi.confsched.naventry.sponsorsEntry
 import io.github.droidkaigi.confsched.naventry.staffEntry
-import io.github.droidkaigi.confsched.navigation.extension.safeRemoveLastIfType
+import io.github.droidkaigi.confsched.navigation.extension.safeRemoveLastPreservingRoot
 import io.github.droidkaigi.confsched.navigation.rememberNavBackStack
 import io.github.droidkaigi.confsched.navigation.sceneStrategy
 import io.github.droidkaigi.confsched.navkey.AboutNavKey
@@ -72,7 +72,7 @@ actual fun KaigiAppUi() {
             sceneStrategy = sceneStrategy(),
             entryProvider = entryProvider {
                 sessionEntries(
-                    onBackClick = { backStack.safeRemoveLastIfType<TimetableItemDetailNavKey>() },
+                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
                     onAddCalendarClick = externalNavController::navigateToCalendarRegistration,
                     onShareClick = externalNavController::onShareClick,
                     onLinkClick = externalNavController::navigate,
@@ -85,15 +85,15 @@ actual fun KaigiAppUi() {
                     },
                 )
                 contributorsEntry(
-                    onBackClick = { backStack.safeRemoveLastIfType<ContributorsNavKey>() },
+                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
                     onContributorClick = externalNavController::navigate,
                 )
                 sponsorsEntry(
-                    onBackClick = { backStack.safeRemoveLastIfType<SponsorsNavKey>() },
+                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
                     onSponsorClick = externalNavController::navigate,
                 )
                 staffEntry(
-                    onBackClick = { backStack.safeRemoveLastIfType<StaffNavKey>() },
+                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
                     onStaffItemClick = externalNavController::navigate,
                 )
                 favoritesEntry(

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -20,6 +20,7 @@ import io.github.droidkaigi.confsched.naventry.profileNavEntry
 import io.github.droidkaigi.confsched.naventry.sessionEntries
 import io.github.droidkaigi.confsched.naventry.sponsorsEntry
 import io.github.droidkaigi.confsched.naventry.staffEntry
+import io.github.droidkaigi.confsched.navigation.extension.safeRemoveLastIfType
 import io.github.droidkaigi.confsched.navigation.rememberNavBackStack
 import io.github.droidkaigi.confsched.navigation.sceneStrategy
 import io.github.droidkaigi.confsched.navkey.AboutNavKey
@@ -71,7 +72,7 @@ actual fun KaigiAppUi() {
             sceneStrategy = sceneStrategy(),
             entryProvider = entryProvider {
                 sessionEntries(
-                    onBackClick = { backStack.removeLastOrNull() },
+                    onBackClick = { backStack.safeRemoveLastIfType<TimetableItemDetailNavKey>() },
                     onAddCalendarClick = externalNavController::navigateToCalendarRegistration,
                     onShareClick = externalNavController::onShareClick,
                     onLinkClick = externalNavController::navigate,
@@ -84,15 +85,15 @@ actual fun KaigiAppUi() {
                     },
                 )
                 contributorsEntry(
-                    onBackClick = { backStack.removeLastOrNull() },
+                    onBackClick = { backStack.safeRemoveLastIfType<ContributorsNavKey>() },
                     onContributorClick = externalNavController::navigate,
                 )
                 sponsorsEntry(
-                    onBackClick = { backStack.removeLastOrNull() },
+                    onBackClick = { backStack.safeRemoveLastIfType<SponsorsNavKey>() },
                     onSponsorClick = externalNavController::navigate,
                 )
                 staffEntry(
-                    onBackClick = { backStack.removeLastOrNull() },
+                    onBackClick = { backStack.safeRemoveLastIfType<StaffNavKey>() },
                     onStaffItemClick = externalNavController::navigate,
                 )
                 favoritesEntry(

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -158,7 +158,7 @@ actual fun KaigiAppUi() {
                             }
                         }
                     },
-                    onBackClick = { backStack.removeLastOrNull() },
+                    onBackClick = { backStack.safeRemoveLastOrNull() },
                 )
                 profileNavEntry()
             },

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -20,7 +20,7 @@ import io.github.droidkaigi.confsched.naventry.profileNavEntry
 import io.github.droidkaigi.confsched.naventry.sessionEntries
 import io.github.droidkaigi.confsched.naventry.sponsorsEntry
 import io.github.droidkaigi.confsched.naventry.staffEntry
-import io.github.droidkaigi.confsched.navigation.extension.safeRemoveLastPreservingRoot
+import io.github.droidkaigi.confsched.navigation.extension.safeRemoveLastOrNull
 import io.github.droidkaigi.confsched.navigation.rememberNavBackStack
 import io.github.droidkaigi.confsched.navigation.sceneStrategy
 import io.github.droidkaigi.confsched.navkey.AboutNavKey
@@ -72,7 +72,7 @@ actual fun KaigiAppUi() {
             sceneStrategy = sceneStrategy(),
             entryProvider = entryProvider {
                 sessionEntries(
-                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
+                    onBackClick = { backStack.safeRemoveLastOrNull() },
                     onAddCalendarClick = externalNavController::navigateToCalendarRegistration,
                     onShareClick = externalNavController::onShareClick,
                     onLinkClick = externalNavController::navigate,
@@ -85,15 +85,15 @@ actual fun KaigiAppUi() {
                     },
                 )
                 contributorsEntry(
-                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
+                    onBackClick = { backStack.safeRemoveLastOrNull() },
                     onContributorClick = externalNavController::navigate,
                 )
                 sponsorsEntry(
-                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
+                    onBackClick = { backStack.safeRemoveLastOrNull() },
                     onSponsorClick = externalNavController::navigate,
                 )
                 staffEntry(
-                    onBackClick = { backStack.safeRemoveLastPreservingRoot() },
+                    onBackClick = { backStack.safeRemoveLastOrNull() },
                     onStaffItemClick = externalNavController::navigate,
                 )
                 favoritesEntry(

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
@@ -2,40 +2,14 @@ package io.github.droidkaigi.confsched.navigation.extension
 
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.navigation3.runtime.NavKey
-import io.github.droidkaigi.confsched.component.MainScreenTab
-import io.github.droidkaigi.confsched.navkey.AboutNavKey
-import io.github.droidkaigi.confsched.navkey.EventMapNavKey
-import io.github.droidkaigi.confsched.navkey.FavoritesNavKey
-import io.github.droidkaigi.confsched.navkey.ProfileNavKey
-import io.github.droidkaigi.confsched.navkey.TimetableNavKey
 
 /**
- * Returns the corresponding NavKey for this MainScreenTab
- */
-val MainScreenTab.navKey: NavKey
-    get() = when (this) {
-        MainScreenTab.Timetable -> TimetableNavKey
-        MainScreenTab.EventMap -> EventMapNavKey
-        MainScreenTab.Favorite -> FavoritesNavKey
-        MainScreenTab.About -> AboutNavKey
-        MainScreenTab.Profile -> ProfileNavKey
-    }
-
-/**
- * All main tab navigation keys that should be preserved in the backstack
- */
-val mainTabNavKeys = MainScreenTab.entries.map { it.navKey }.toSet()
-
-/**
- * Safely removes the last item from the backstack while preserving root navigation keys.
- * Root keys include main tab navigation keys that should never be removed to prevent empty backstack.
+ * Safely removes the last item from the backstack.
  * Prevents "java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty"
- * when rapidly tapping back buttons in navigation3.
+ * when the system back button and UI back button are pressed simultaneously in navigation3.
  */
-fun SnapshotStateList<NavKey>.safeRemoveLastPreservingRoot(): NavKey? {
-    val isRootNavKey = lastOrNull() in mainTabNavKeys
-
-    return if (size > 1 && !isRootNavKey) {
+fun SnapshotStateList<NavKey>.safeRemoveLastOrNull(): NavKey? {
+    return if (size > 1) {
         removeLastOrNull()
     } else {
         null

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
@@ -2,15 +2,40 @@ package io.github.droidkaigi.confsched.navigation.extension
 
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.navigation3.runtime.NavKey
+import io.github.droidkaigi.confsched.component.MainScreenTab
+import io.github.droidkaigi.confsched.navkey.AboutNavKey
+import io.github.droidkaigi.confsched.navkey.EventMapNavKey
+import io.github.droidkaigi.confsched.navkey.FavoritesNavKey
+import io.github.droidkaigi.confsched.navkey.ProfileNavKey
+import io.github.droidkaigi.confsched.navkey.TimetableNavKey
 
 /**
- * Safely removes the last item from the backstack only if it matches the expected type.
+ * Returns the corresponding NavKey for this MainScreenTab
+ */
+val MainScreenTab.navKey: NavKey
+    get() = when (this) {
+        MainScreenTab.Timetable -> TimetableNavKey
+        MainScreenTab.EventMap -> EventMapNavKey
+        MainScreenTab.Favorite -> FavoritesNavKey
+        MainScreenTab.About -> AboutNavKey
+        MainScreenTab.Profile -> ProfileNavKey
+    }
+
+/**
+ * All main tab navigation keys that should be preserved in the backstack
+ */
+val mainTabNavKeys = MainScreenTab.entries.map { it.navKey }.toSet()
+
+/**
+ * Safely removes the last item from the backstack while preserving root navigation keys.
+ * Root keys include main tab navigation keys that should never be removed to prevent empty backstack.
  * Prevents "java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty"
  * when rapidly tapping back buttons in navigation3.
  */
-
-inline fun <reified T : NavKey> SnapshotStateList<NavKey>.safeRemoveLastIfType(): NavKey? {
-    return if (isNotEmpty() && lastOrNull() is T) {
+fun SnapshotStateList<NavKey>.safeRemoveLastPreservingRoot(): NavKey? {
+    val isRootNavKey = lastOrNull() in mainTabNavKeys
+    
+    return if (size > 1 && !isRootNavKey) {
         removeLastOrNull()
     } else {
         null

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
@@ -34,7 +34,7 @@ val mainTabNavKeys = MainScreenTab.entries.map { it.navKey }.toSet()
  */
 fun SnapshotStateList<NavKey>.safeRemoveLastPreservingRoot(): NavKey? {
     val isRootNavKey = lastOrNull() in mainTabNavKeys
-    
+
     return if (size > 1 && !isRootNavKey) {
         removeLastOrNull()
     } else {

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/BackStackExtensions.kt
@@ -1,0 +1,18 @@
+package io.github.droidkaigi.confsched.navigation.extension
+
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.navigation3.runtime.NavKey
+
+/**
+ * Safely removes the last item from the backstack only if it matches the expected type.
+ * Prevents "java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty"
+ * when rapidly tapping back buttons in navigation3.
+ */
+
+inline fun <reified T : NavKey> SnapshotStateList<NavKey>.safeRemoveLastIfType(): NavKey? {
+    return if (isNotEmpty() && lastOrNull() is T) {
+        removeLastOrNull()
+    } else {
+        null
+    }
+}


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/264

## Overview (Required)
- Prevents "java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty"
  when rapidly tapping back buttons in navigation3 by adding type-safe removal functions.
- ~~Replace type-specific back handling with MainScreenTab-based approach.
This fixes UI-level back handling on SearchScreen and other non-main screens
while still preventing backstack empty crashes on rapid tapping.~~

## Links
- https://blog.csdn.net/qq_50675668/article/details/149772402
- https://github.com/android/androidify/pull/13
- https://issuetracker.google.com/issues/419017866

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/307bbcb4-ead9-4252-b059-d8a95ff3a763" width="300" > | <video src="https://github.com/user-attachments/assets/27d8f733-5b4b-462f-988d-310529139bf6" width="300" >
