### PR TITLE
Add Screenshot Test for SearchScreen

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
@@ -33,6 +33,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
@@ -52,6 +56,15 @@ import io.github.droidkaigi.confsched.model.sessions.fake
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
+const val TimetableItemCardTestTag = "TimetableListItem"
+
+const val TimetableItemCardTitleTextTestTag = "TimetableItemCardTitleText"
+
+private val timetableItemCardSemanticsKey = SemanticsPropertyKey<TimetableItem>("TimetableItem")
+
+@Suppress("UnusedReceiverParameter")
+val SemanticsProperties.TimetableItemCard get() = timetableItemCardSemanticsKey
+
 @Composable
 fun TimetableItemCard(
     timetableItem: TimetableItem,
@@ -68,6 +81,10 @@ fun TimetableItemCard(
         Row(
             verticalAlignment = Alignment.Top,
             modifier = modifier
+                .testTag(TimetableItemCardTestTag)
+                .semantics {
+                    this[SemanticsProperties.TimetableItemCard] = timetableItem
+                }
                 .clip(RoundedCornerShape(16.dp))
                 .clickable { onTimetableItemClick() }
                 .background(Color.Transparent)
@@ -209,6 +226,7 @@ private fun TimetableItemTitle(
     }
 
     Text(
+        modifier = Modifier.testTag(TimetableItemCardTitleTextTestTag),
         text = highlightedTitle,
         style = MaterialTheme.typography.titleLarge,
     )

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -42,6 +42,8 @@ kotlin {
             implementation(libs.lifecycleRuntimeCompose)
             implementation(libs.androidxDatastorePreferencesCore)
             implementation(libs.material3)
+
+            implementation(kotlin("test"))
         }
 
         androidMain.dependencies {

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/SearchScreenTestGraph.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/SearchScreenTestGraph.kt
@@ -1,0 +1,17 @@
+package io.github.droidkaigi.confsched.testing.di
+
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import io.github.droidkaigi.confsched.sessions.SearchScreenContext
+import io.github.droidkaigi.confsched.testing.robot.search.SearchScreenRobot
+
+interface SearchScreenTestGraph : SearchScreenContext.Factory {
+    val searchScreenRobotProvider: Provider<SearchScreenRobot>
+
+    @Provides
+    fun provideSearchScreenContext(): SearchScreenContext {
+        return createSearchScreenContext()
+    }
+}
+
+fun createSearchScreenTestGraph(): SearchScreenTestGraph = createTestAppGraph()

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.kt
@@ -19,7 +19,8 @@ internal interface TestAppGraph :
     AboutScreenTestGraph,
     ContributorsScreenTestGraph,
     EventMapScreenTestGraph,
-    StaffScreenTestGraph {
+    StaffScreenTestGraph,
+    SearchScreenTestGraph {
 
     @Binds
     val FakeSessionsApiClient.binds: SessionsApiClient

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import dev.zacsweers.metro.Inject
+import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultErrorFallbackContentTestTag
 import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultSuspenseFallbackContentTestTag
 import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCard
 import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardTestTag
@@ -103,6 +104,11 @@ class SearchScreenRobot(
     context(composeUiTest: ComposeUiTest)
     fun checkLoadingIndicatorDisplayed() {
         composeUiTest.onNodeWithTag(DefaultSuspenseFallbackContentTestTag).assertExists()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkErrorMessageDisplayed() {
+        composeUiTest.onNodeWithTag(DefaultErrorFallbackContentTestTag).assertExists()
     }
 
     context(composeUiTest: ComposeUiTest)

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
@@ -74,10 +74,10 @@ class SearchScreenRobot(
     }
 
     enum class SessionType(
-        val typeName: String,
+        val label: String,
     ) {
-        WelcomeTalk("WELCOME_TALK"),
-        Normal("Normal"),
+        WelcomeTalk("Welcome Talk"),
+        Normal("Session"),
     }
 
     enum class Language(
@@ -203,7 +203,7 @@ class SearchScreenRobot(
                 testTag = DropdownFilterChipTestTagPrefix,
                 substring = true,
             )
-            .filter(matcher = hasText(sessionType.typeName))
+            .filter(matcher = hasText(sessionType.label))
             .onFirst()
             .performClick()
         waitUntilIdle()
@@ -300,6 +300,19 @@ class SearchScreenRobot(
                 value = containText,
                 substring = true,
             )
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemBySessionType(
+        sessionType: SessionType,
+    ) {
+        composeUiTest
+            .onAllNodesWithTag(TimetableItemCardTestTag)
+            .onFirst()
+            .assertSemanticsProperty(SemanticsProperties.TimetableItemCard) { item ->
+                item?.sessionType?.label?.enTitle == sessionType.label
+            }
         waitUntilIdle()
     }
 

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
@@ -88,7 +88,7 @@ class SearchScreenRobot(
     }
 
     context(composeUiTest: ComposeUiTest)
-    fun setupTimetableScreenContent() {
+    fun setupSearchScreenContent() {
         composeUiTest.setContent {
             with(screenContext) {
                 TestDefaultsProvider(testDispatcher) {

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
@@ -1,0 +1,296 @@
+package io.github.droidkaigi.confsched.testing.robot.search
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertAll
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.filter
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextInput
+import dev.zacsweers.metro.Inject
+import io.github.droidkaigi.confsched.sessions.SearchScreenContext
+import io.github.droidkaigi.confsched.sessions.SearchScreenRoot
+import io.github.droidkaigi.confsched.testing.compose.TestDefaultsProvider
+import io.github.droidkaigi.confsched.testing.robot.core.CaptureScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.DefaultCaptureScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.DefaultWaitRobot
+import io.github.droidkaigi.confsched.testing.robot.core.WaitRobot
+import io.github.droidkaigi.confsched.testing.robot.sessions.DefaultTimetableServerRobot
+import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot
+import kotlinx.coroutines.test.TestDispatcher
+
+private const val DemoSearchWord = "Demo"
+
+@Inject
+class SearchScreenRobot(
+    private val screenContext: SearchScreenContext,
+    private val testDispatcher: TestDispatcher,
+    timetableServerRobot: DefaultTimetableServerRobot,
+    captureScreenRobot: DefaultCaptureScreenRobot,
+    waitRobot: DefaultWaitRobot,
+) : TimetableServerRobot by timetableServerRobot,
+    CaptureScreenRobot by captureScreenRobot,
+    WaitRobot by waitRobot {
+
+    enum class ConferenceDay(
+        val day: Int,
+        val dateText: String,
+    ) {
+        Day1(1, "9/12"),
+        Day2(2, "9/13"),
+    }
+
+    enum class Category(
+        val categoryName: String,
+    ) {
+        AppArchitecture("App Architecture en"),
+        JetpackCompose("Jetpack Compose en"),
+        Other("Other en"),
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun setupTimetableScreenContent() {
+        composeUiTest.setContent {
+            with(screenContext) {
+                TestDefaultsProvider(testDispatcher) {
+                    SearchScreenRoot(
+                        onTimetableItemClick = {},
+                        onBackClick = {},
+                    )
+                }
+            }
+        }
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun inputDemoSearchWord() {
+        inputSearchWord(DemoSearchWord)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    private fun inputSearchWord(text: String) {
+        composeTestRule
+            .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
+            .performTextInput(text)
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun scrollToFilterLanguageChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersLazyRowTestTag))
+            .performScrollToNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickFilterDayChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersFilterDayChipTestTag))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickFilterCategoryChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersFilterCategoryChipTestTag))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickFilterLanguageChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickConferenceDay(
+        clickDay: ConferenceDay,
+    ) {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .filter(matcher = hasText(clickDay.dateText))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickCategory(
+        category: Category,
+    ) {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .filter(matcher = hasText(category.categoryName))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickLanguage(
+        language: Language,
+    ) {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .filter(matcher = hasText(language.tagName))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkDisplayedFilterDayChip() {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .assertCountAtLeast(ConferenceDay.entries.size)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkDisplayedFilterCategoryChip() {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .assertCountAtLeast(Category.entries.size)
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkDisplayedFilterLanguageChip() {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .assertCountAtLeast(Language.entries.size)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemByConferenceDay(
+        checkDay: ConferenceDay,
+    ) {
+        val (contain, doesNotContain) = if (checkDay == ConferenceDay.Day1) {
+            listOf(ConferenceDay.Day1, ConferenceDay.Day2)
+        } else {
+            listOf(ConferenceDay.Day2, ConferenceDay.Day1)
+        }
+
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+            .onFirst()
+            .assertTextContains("Demo Welcome Talk ${contain.day}")
+            .assertTextDoesNotContain("Demo Welcome Talk ${doesNotContain.day}")
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemByCategory(
+        category: Category,
+    ) {
+        val containText = if (category == Category.Other) {
+            "Demo Welcome Talk"
+        } else {
+            category.categoryName
+        }
+
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+            .onFirst()
+            .assertTextContains(
+                value = containText,
+                substring = true,
+            )
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkDemoSearchWordDisplayed() {
+        checkSearchWordDisplayed(DemoSearchWord)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    private fun checkSearchWordDisplayed(text: String) {
+        composeTestRule
+            .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
+            .assertTextEquals(text)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemsHasDemoText() {
+        checkTimetableListItemsHasText(DemoSearchWord)
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    private fun checkTimetableListItemsHasText(searchWord: String) {
+        composeTestRule
+            .onAllNodesWithTag(TimetableItemCardTitleTextTestTag)
+            .assertAll(hasText(text = searchWord, ignoreCase = true))
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListExists() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableListTestTag))
+            .assertExists()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListDisplayed() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableListTestTag))
+            .assertIsDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemsDisplayed() {
+        composeTestRule
+            .onAllNodesWithTag(TimetableItemCardTestTag)
+            .onFirst()
+            .assertIsDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemsNotDisplayed() {
+        composeTestRule
+            .onAllNodesWithTag(TimetableItemCardTestTag)
+            .onFirst()
+            .assertIsNotDisplayed()
+    }
+}

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
@@ -60,8 +60,8 @@ class SearchScreenRobot(
         val day: Int,
         val dateText: String,
     ) {
-        Day1(1, "9/12"),
-        Day2(2, "9/13"),
+        Day1(1, "9.11"),
+        Day2(2, "9.12"),
     }
 
     enum class Category(
@@ -75,14 +75,13 @@ class SearchScreenRobot(
     enum class SessionType(
         val typeName: String,
     ) {
-        WelcomeTalk("WelcomeTalk"),
+        WelcomeTalk("WELCOME_TALK"),
         Normal("Normal"),
     }
 
     enum class Language(
         val tagName: String,
     ) {
-        Mixed("MIXED"),
         Japanese("JA"),
         English("EN"),
     }
@@ -213,7 +212,7 @@ class SearchScreenRobot(
                 testTag = DropdownFilterChipTestTagPrefix,
                 substring = true,
             )
-            .filter(matcher = hasText(language.tagName))
+            .filter(matcher = hasText(language.tagName, ignoreCase = true, substring = true))
             .onFirst()
             .performClick()
         waitUntilIdle()
@@ -344,10 +343,10 @@ class SearchScreenRobot(
     }
 
     context(composeUiTest: ComposeUiTest)
-    fun checkTimetableListExists() {
+    fun checkTimetableListNotDisplayed() {
         composeUiTest
             .onNodeWithTag(TimetableListTestTag)
-            .assertExists()
+            .assertIsNotDisplayed()
     }
 
     context(composeUiTest: ComposeUiTest)

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/search/SearchScreenRobot.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.testing.robot.search
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertIsDisplayed
@@ -9,15 +10,26 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import dev.zacsweers.metro.Inject
+import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultSuspenseFallbackContentTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCard
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardTitleTextTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableListTestTag
 import io.github.droidkaigi.confsched.sessions.SearchScreenContext
 import io.github.droidkaigi.confsched.sessions.SearchScreenRoot
+import io.github.droidkaigi.confsched.sessions.components.DropdownFilterChipTestTagPrefix
+import io.github.droidkaigi.confsched.sessions.components.SearchFilterRowFilterCategoryChipTestTag
+import io.github.droidkaigi.confsched.sessions.components.SearchFilterRowFilterDayChipTestTag
+import io.github.droidkaigi.confsched.sessions.components.SearchFilterRowFilterLanguageChipTestTag
+import io.github.droidkaigi.confsched.sessions.components.SearchFilterRowFilterSessionTypeChipTestTag
+import io.github.droidkaigi.confsched.sessions.components.SearchFilterRowTestTag
+import io.github.droidkaigi.confsched.sessions.components.SearchTopBarTextFieldTestTag
 import io.github.droidkaigi.confsched.testing.compose.TestDefaultsProvider
 import io.github.droidkaigi.confsched.testing.robot.core.CaptureScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.core.DefaultCaptureScreenRobot
@@ -25,6 +37,10 @@ import io.github.droidkaigi.confsched.testing.robot.core.DefaultWaitRobot
 import io.github.droidkaigi.confsched.testing.robot.core.WaitRobot
 import io.github.droidkaigi.confsched.testing.robot.sessions.DefaultTimetableServerRobot
 import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot
+import io.github.droidkaigi.confsched.testing.util.assertCountAtLeast
+import io.github.droidkaigi.confsched.testing.util.assertSemanticsProperty
+import io.github.droidkaigi.confsched.testing.util.assertTextDoesNotContain
+import io.github.droidkaigi.confsched.testing.util.onAllNodesWithTag
 import kotlinx.coroutines.test.TestDispatcher
 
 private const val DemoSearchWord = "Demo"
@@ -56,6 +72,21 @@ class SearchScreenRobot(
         Other("Other en"),
     }
 
+    enum class SessionType(
+        val typeName: String,
+    ) {
+        WelcomeTalk("WelcomeTalk"),
+        Normal("Normal"),
+    }
+
+    enum class Language(
+        val tagName: String,
+    ) {
+        Mixed("MIXED"),
+        Japanese("JA"),
+        English("EN"),
+    }
+
     context(composeUiTest: ComposeUiTest)
     fun setupTimetableScreenContent() {
         composeUiTest.setContent {
@@ -71,46 +102,59 @@ class SearchScreenRobot(
     }
 
     context(composeUiTest: ComposeUiTest)
+    fun checkLoadingIndicatorDisplayed() {
+        composeUiTest.onNodeWithTag(DefaultSuspenseFallbackContentTestTag).assertExists()
+    }
+
+    context(composeUiTest: ComposeUiTest)
     fun inputDemoSearchWord() {
         inputSearchWord(DemoSearchWord)
     }
 
     context(composeUiTest: ComposeUiTest)
     private fun inputSearchWord(text: String) {
-        composeTestRule
-            .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
+        composeUiTest
+            .onNodeWithTag(SearchTopBarTextFieldTestTag)
             .performTextInput(text)
         waitUntilIdle()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun scrollToFilterLanguageChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersLazyRowTestTag))
-            .performScrollToNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
+        composeUiTest
+            .onNodeWithTag(SearchFilterRowTestTag)
+            .performScrollToNode(hasTestTag(SearchFilterRowFilterLanguageChipTestTag))
         waitUntilIdle()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun clickFilterDayChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersFilterDayChipTestTag))
+        composeUiTest
+            .onNodeWithTag(SearchFilterRowFilterDayChipTestTag)
             .performClick()
         waitUntilIdle()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun clickFilterCategoryChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersFilterCategoryChipTestTag))
+        composeUiTest
+            .onNodeWithTag(SearchFilterRowFilterCategoryChipTestTag)
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickFilterSessionTypeChip() {
+        composeUiTest
+            .onNodeWithTag(SearchFilterRowFilterSessionTypeChipTestTag)
             .performClick()
         waitUntilIdle()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun clickFilterLanguageChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
+        composeUiTest
+            .onNodeWithTag(SearchFilterRowFilterLanguageChipTestTag)
             .performClick()
         waitUntilIdle()
     }
@@ -119,12 +163,10 @@ class SearchScreenRobot(
     fun clickConferenceDay(
         clickDay: ConferenceDay,
     ) {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
             )
             .filter(matcher = hasText(clickDay.dateText))
             .onFirst()
@@ -136,14 +178,27 @@ class SearchScreenRobot(
     fun clickCategory(
         category: Category,
     ) {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
             )
             .filter(matcher = hasText(category.categoryName))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickSessionType(
+        sessionType: SessionType,
+    ) {
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
+            )
+            .filter(matcher = hasText(sessionType.typeName))
             .onFirst()
             .performClick()
         waitUntilIdle()
@@ -153,12 +208,10 @@ class SearchScreenRobot(
     fun clickLanguage(
         language: Language,
     ) {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
             )
             .filter(matcher = hasText(language.tagName))
             .onFirst()
@@ -168,37 +221,42 @@ class SearchScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     fun checkDisplayedFilterDayChip() {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
             )
             .assertCountAtLeast(ConferenceDay.entries.size)
     }
 
     context(composeUiTest: ComposeUiTest)
     fun checkDisplayedFilterCategoryChip() {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
             )
             .assertCountAtLeast(Category.entries.size)
         waitUntilIdle()
     }
 
     context(composeUiTest: ComposeUiTest)
+    fun checkDisplayedFilterSessionTypeChip() {
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
+            )
+            .assertCountAtLeast(SessionType.entries.size)
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
     fun checkDisplayedFilterLanguageChip() {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
+        composeUiTest
+            .onAllNodesWithTag(
+                testTag = DropdownFilterChipTestTagPrefix,
+                substring = true,
             )
             .assertCountAtLeast(Language.entries.size)
     }
@@ -213,8 +271,8 @@ class SearchScreenRobot(
             listOf(ConferenceDay.Day2, ConferenceDay.Day1)
         }
 
-        composeTestRule
-            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+        composeUiTest
+            .onAllNodesWithTag(TimetableItemCardTestTag)
             .onFirst()
             .assertTextContains("Demo Welcome Talk ${contain.day}")
             .assertTextDoesNotContain("Demo Welcome Talk ${doesNotContain.day}")
@@ -230,8 +288,8 @@ class SearchScreenRobot(
             category.categoryName
         }
 
-        composeTestRule
-            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+        composeUiTest
+            .onAllNodesWithTag(TimetableItemCardTestTag)
             .onFirst()
             .assertTextContains(
                 value = containText,
@@ -241,14 +299,35 @@ class SearchScreenRobot(
     }
 
     context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemByLanguage(language: Language) {
+        val doesNotContains = Language.entries.filterNot { it == language }
+
+        composeUiTest
+            .onAllNodesWithTag(TimetableItemCardTestTag)
+            .onFirst()
+            .assertSemanticsProperty(SemanticsProperties.TimetableItemCard) { item ->
+                item?.language?.toLang()?.tagName == language.tagName
+            }
+
+        doesNotContains.forEach { doesNotContain ->
+            composeUiTest
+                .onAllNodesWithTag(TimetableItemCardTestTag)
+                .onFirst()
+                .assertSemanticsProperty(SemanticsProperties.TimetableItemCard) { item ->
+                    item?.language?.toLang()?.tagName != doesNotContain.tagName
+                }
+        }
+    }
+
+    context(composeUiTest: ComposeUiTest)
     fun checkDemoSearchWordDisplayed() {
         checkSearchWordDisplayed(DemoSearchWord)
     }
 
     context(composeUiTest: ComposeUiTest)
     private fun checkSearchWordDisplayed(text: String) {
-        composeTestRule
-            .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
+        composeUiTest
+            .onNodeWithTag(SearchTopBarTextFieldTestTag)
             .assertTextEquals(text)
     }
 
@@ -259,28 +338,28 @@ class SearchScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     private fun checkTimetableListItemsHasText(searchWord: String) {
-        composeTestRule
+        composeUiTest
             .onAllNodesWithTag(TimetableItemCardTitleTextTestTag)
             .assertAll(hasText(text = searchWord, ignoreCase = true))
     }
 
     context(composeUiTest: ComposeUiTest)
     fun checkTimetableListExists() {
-        composeTestRule
-            .onNode(hasTestTag(TimetableListTestTag))
+        composeUiTest
+            .onNodeWithTag(TimetableListTestTag)
             .assertExists()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun checkTimetableListDisplayed() {
-        composeTestRule
-            .onNode(hasTestTag(TimetableListTestTag))
+        composeUiTest
+            .onNodeWithTag(TimetableListTestTag)
             .assertIsDisplayed()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun checkTimetableListItemsDisplayed() {
-        composeTestRule
+        composeUiTest
             .onAllNodesWithTag(TimetableItemCardTestTag)
             .onFirst()
             .assertIsDisplayed()
@@ -288,7 +367,7 @@ class SearchScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     fun checkTimetableListItemsNotDisplayed() {
-        composeTestRule
+        composeUiTest
             .onAllNodesWithTag(TimetableItemCardTestTag)
             .onFirst()
             .assertIsNotDisplayed()

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/util/Matchers.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/util/Matchers.kt
@@ -2,10 +2,14 @@ package io.github.droidkaigi.confsched.testing.util
 
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import kotlin.test.DefaultAsserter.assertTrue
+import kotlin.test.assertFalse
 
 fun hasTestTag(
     testTag: String,
@@ -50,6 +54,44 @@ fun SemanticsNodeInteractionCollection.assertCountAtLeast(
         )
     }
     return this
+}
+
+fun SemanticsNodeInteraction.assertTextDoesNotContain(
+    substring: String,
+) {
+    fetchSemanticsNode()
+        .let { node ->
+            val textProperty = node
+                .config
+                .getOrNull(
+                    key = SemanticsProperties.Text,
+                )
+            val textContent = textProperty
+                ?.joinToString(
+                    separator = " ",
+                ) { it.text }
+            assertFalse(
+                message = "Node text contains unexpected substring: $substring",
+                actual = textContent?.contains(substring) ?: false,
+            )
+        }
+}
+
+fun <T> SemanticsNodeInteraction.assertSemanticsProperty(
+    key: SemanticsPropertyKey<T>,
+    condition: (T?) -> Boolean,
+) {
+    fetchSemanticsNode()
+        .let { node ->
+            val actual = node
+                .config
+                .getOrNull(key)
+
+            assertTrue(
+                message = "Node has unexpected value for semantics property $key: $actual",
+                actual = condition(actual),
+            )
+        }
 }
 
 private fun buildErrorMessageForMinimumCountMismatch(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchFilterRow.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchFilterRow.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.sessions.SearchScreenEvent
 import io.github.droidkaigi.confsched.sessions.SearchScreenUiState
@@ -32,6 +33,14 @@ import io.github.droidkaigi.confsched.sessions.filter_chip_day
 import io.github.droidkaigi.confsched.sessions.filter_chip_session_type
 import io.github.droidkaigi.confsched.sessions.filter_chip_supported_language
 import org.jetbrains.compose.resources.stringResource
+
+const val SearchFilterRowTestTag = "SearchFilterRowTestTag"
+const val SearchFilterRowFilterDayChipTestTag = "SearchFilterRowFilterDayChipTestTag"
+const val SearchFilterRowFilterCategoryChipTestTag = "SearchFilterRowFilterCategoryChipTestTag"
+const val SearchFilterRowFilterSessionTypeChipTestTag = "SearchFilterRowFilterSessionTypeChipTestTag"
+const val SearchFilterRowFilterLanguageChipTestTag = "SearchFilterRowFilterLanguageChipTestTag"
+
+const val DropdownFilterChipTestTagPrefix = "DropdownFilterChipTestTag:"
 
 @Composable
 fun SearchFilterRow(
@@ -44,7 +53,8 @@ fun SearchFilterRow(
     Row(
         modifier = modifier
             .horizontalScroll(scrollState)
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag(SearchFilterRowTestTag),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         // Day filter dropdown
@@ -57,7 +67,7 @@ fun SearchFilterRow(
                 onItemSelected = { day ->
                     onFilterToggle(SearchScreenEvent.Filter.Day(day))
                 },
-                modifier = Modifier,
+                modifier = Modifier.testTag(SearchFilterRowFilterDayChipTestTag),
             )
         }
 
@@ -71,7 +81,7 @@ fun SearchFilterRow(
                 onItemSelected = { category ->
                     onFilterToggle(SearchScreenEvent.Filter.Category(category))
                 },
-                modifier = Modifier,
+                modifier = Modifier.testTag(SearchFilterRowFilterCategoryChipTestTag),
             )
         }
 
@@ -85,7 +95,7 @@ fun SearchFilterRow(
                 onItemSelected = { sessionType ->
                     onFilterToggle(SearchScreenEvent.Filter.SessionType(sessionType))
                 },
-                modifier = Modifier,
+                modifier = Modifier.testTag(SearchFilterRowFilterSessionTypeChipTestTag),
             )
         }
 
@@ -99,7 +109,7 @@ fun SearchFilterRow(
                 onItemSelected = { language ->
                     onFilterToggle(SearchScreenEvent.Filter.Language(language))
                 },
-                modifier = Modifier,
+                modifier = Modifier.testTag(SearchFilterRowFilterLanguageChipTestTag),
             )
         }
     }
@@ -158,6 +168,7 @@ private fun <T> FilterDropdown(
         ) {
             items.forEach { item ->
                 DropdownMenuItem(
+                    modifier = Modifier.testTag(DropdownFilterChipTestTagPrefix.plus(item)),
                     text = { Text(itemLabel(item)) },
                     onClick = {
                         onItemSelected(item)

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchTopBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchTopBar.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 
-const val SearchTopBarTextFieldTestTag = "SearchTopBarTextFieldTest"
+const val SearchTopBarTextFieldTestTag = "SearchTopBarTextFieldTestTag"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchTopBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchTopBar.kt
@@ -22,7 +22,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
+
+const val SearchTopBarTextFieldTestTag = "SearchTopBarTextFieldTest"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,7 +60,8 @@ fun SearchTopBar(
                 ),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(focusRequester),
+                    .focusRequester(focusRequester)
+                    .testTag(SearchTopBarTextFieldTestTag),
             )
         },
         navigationIcon = {

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -40,6 +40,107 @@ class SearchScreenTest {
                 doIt {
                     waitFor5Seconds()
                 }
+                itShould("no timetable items are displayed") {
+                    captureScreenWithChecks {
+                        checkTimetableListNotDisplayed()
+                        checkTimetableListItemsNotDisplayed()
+                    }
+                }
+                describe("input search word to TextField") {
+                    doIt {
+                        inputDemoSearchWord()
+                    }
+                    itShould("show search word and filtered items") {
+                        captureScreenWithChecks {
+                            checkDemoSearchWordDisplayed()
+                            checkTimetableListItemsHasDemoText()
+                            checkTimetableListDisplayed()
+                            checkTimetableListItemsDisplayed()
+                        }
+                    }
+                }
+                describe("when filter day chip click") {
+                    doIt {
+                        clickFilterDayChip()
+                    }
+                    itShould("show drop down menu") {
+                        captureScreenWithChecks {
+                            checkDisplayedFilterDayChip()
+                        }
+                    }
+                    SearchScreenRobot.ConferenceDay.entries.forEach { conference ->
+                        describe("when click ${conference.day}") {
+                            doIt {
+                                clickConferenceDay(
+                                    clickDay = conference,
+                                )
+                            }
+                            itShould("selected ${conference.day}") {
+                                captureScreenWithChecks {
+                                    checkTimetableListItemByConferenceDay(
+                                        checkDay = conference,
+                                    )
+                                    checkTimetableListDisplayed()
+                                    checkTimetableListItemsDisplayed()
+                                }
+                            }
+                        }
+                    }
+                }
+                describe("when filter category chip click") {
+                    doIt {
+                        clickFilterCategoryChip()
+                    }
+                    itShould("show drop down menu") {
+                        captureScreenWithChecks {
+                            checkDisplayedFilterCategoryChip()
+                        }
+                    }
+                    SearchScreenRobot.Category.entries.forEach { category ->
+                        describe("when click ${category.categoryName}") {
+                            doIt {
+                                clickCategory(
+                                    category = category,
+                                )
+                            }
+                            itShould("selected ${category.categoryName}") {
+                                captureScreenWithChecks {
+                                    checkTimetableListItemByCategory(category)
+                                    checkTimetableListDisplayed()
+                                    checkTimetableListItemsDisplayed()
+                                }
+                            }
+                        }
+                    }
+                }
+                // TODO add session type filter chip test
+                describe("when filter language chip click") {
+                    doIt {
+                        scrollToFilterLanguageChip()
+                        clickFilterLanguageChip()
+                    }
+                    itShould("show drop down menu") {
+                        captureScreenWithChecks {
+                            checkDisplayedFilterLanguageChip()
+                        }
+                    }
+                    SearchScreenRobot.Language.entries.forEach { language ->
+                        describe("when click ${language.name}") {
+                            doIt {
+                                clickLanguage(
+                                    language = language,
+                                )
+                            }
+                            itShould("selected ${language.name}") {
+                                captureScreenWithChecks {
+                                    checkTimetableListItemByLanguage(language)
+                                    checkTimetableListDisplayed()
+                                    checkTimetableListItemsDisplayed()
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         describe("when server is error") {

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -1,0 +1,60 @@
+package io.github.droidkaigi.confsched.sessions
+
+import androidx.compose.ui.test.runComposeUiTest
+import io.github.droidkaigi.confsched.testing.annotations.ComposeTest
+import io.github.droidkaigi.confsched.testing.annotations.RunWith
+import io.github.droidkaigi.confsched.testing.annotations.UiTestRunner
+import io.github.droidkaigi.confsched.testing.behavior.describeBehaviors
+import io.github.droidkaigi.confsched.testing.behavior.execute
+import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot.ServerStatus
+
+@RunWith(UiTestRunner::class)
+class SearchScreenTest {
+
+    val testAppGraph = createSearchScreenTestGraph()
+
+    @ComposeTest
+    fun runTest() {
+        describedBehaviors.forEach { behavior ->
+            val robot = testAppGraph.timetableScreenRobotProvider()
+            runComposeUiTest {
+                behavior.execute(robot)
+            }
+        }
+    }
+
+    val describedBehaviors = describeBehaviors<SearchScreenRobot>("SearchScreen") {
+        describe("when server is operational") {
+            doIt {
+                setupTimetableServer(ServerStatus.Operational)
+                setupTimetableScreenContent()
+            }
+            itShould("show loading indicator") {
+                captureScreenWithChecks {
+                    checkLoadingIndicatorDisplayed()
+                }
+            }
+            describe("after loading") {
+                doIt {
+                    waitFor5Seconds()
+                }
+            }
+        }
+        describe("when server is error") {
+            doIt {
+                setupTimetableServer(ServerStatus.Error)
+                setupTimetableScreenContent()
+            }
+            itShould("show loading indicator") {
+                captureScreenWithChecks {
+                    checkLoadingIndicatorDisplayed()
+                }
+            }
+            describe("after loading") {
+                doIt {
+                    waitFor5Seconds()
+                }
+            }
+        }
+    }
+}

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -29,7 +29,7 @@ class SearchScreenTest {
         describe("when server is operational") {
             doIt {
                 setupTimetableServer(ServerStatus.Operational)
-                setupTimetableScreenContent()
+                setupSearchScreenContent()
             }
             itShould("show loading indicator") {
                 captureScreenWithChecks {
@@ -171,7 +171,7 @@ class SearchScreenTest {
         describe("when server is error") {
             doIt {
                 setupTimetableServer(ServerStatus.Error)
-                setupTimetableScreenContent()
+                setupSearchScreenContent()
             }
             itShould("show loading indicator") {
                 captureScreenWithChecks {

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -6,6 +6,8 @@ import io.github.droidkaigi.confsched.testing.annotations.RunWith
 import io.github.droidkaigi.confsched.testing.annotations.UiTestRunner
 import io.github.droidkaigi.confsched.testing.behavior.describeBehaviors
 import io.github.droidkaigi.confsched.testing.behavior.execute
+import io.github.droidkaigi.confsched.testing.di.createSearchScreenTestGraph
+import io.github.droidkaigi.confsched.testing.robot.search.SearchScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot.ServerStatus
 
 @RunWith(UiTestRunner::class)
@@ -16,7 +18,7 @@ class SearchScreenTest {
     @ComposeTest
     fun runTest() {
         describedBehaviors.forEach { behavior ->
-            val robot = testAppGraph.timetableScreenRobotProvider()
+            val robot = testAppGraph.searchScreenRobotProvider()
             runComposeUiTest {
                 behavior.execute(robot)
             }

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -113,7 +113,32 @@ class SearchScreenTest {
                         }
                     }
                 }
-                // TODO add session type filter chip test
+                describe("when filter session type chip click") {
+                    doIt {
+                        clickFilterSessionTypeChip()
+                    }
+                    itShould("show drop down menu") {
+                        captureScreenWithChecks {
+                            checkDisplayedFilterSessionTypeChip()
+                        }
+                    }
+                    SearchScreenRobot.SessionType.entries.forEach { sessionType ->
+                        describe("when click ${sessionType.name}") {
+                            doIt {
+                                clickSessionType(
+                                    sessionType = sessionType,
+                                )
+                            }
+                            itShould("selected ${sessionType.name}") {
+                                captureScreenWithChecks {
+                                    checkTimetableListItemBySessionType(sessionType)
+                                    checkTimetableListDisplayed()
+                                    checkTimetableListItemsDisplayed()
+                                }
+                            }
+                        }
+                    }
+                }
                 describe("when filter language chip click") {
                     doIt {
                         scrollToFilterLanguageChip()

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -157,6 +157,11 @@ class SearchScreenTest {
                 doIt {
                     waitFor5Seconds()
                 }
+                itShould("show error message") {
+                    captureScreenWithChecks {
+                        checkErrorMessageDisplayed()
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Issue
- close #154 

## Overview (Required)
- implemented SearchScreenTest based on last year's robot test class.
- Also, since there was no robot that handled SessionType, I added that as well.

## Links
- [TimetableScreenTest example](https://github.com/DroidKaigi/conference-app-2025/blob/main/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt)
- [Last year's implementation](https://github.com/DroidKaigi/conference-app-2024/blob/main/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
