### PR TITLE
Add Screenshot Test for FavoritesScreen

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/user/UserDataStore.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/user/UserDataStore.kt
@@ -68,6 +68,12 @@ public class UserDataStore(
         }
     }
 
+    public suspend fun clearFavorites() {
+        dataStore.edit { preferences ->
+            preferences.remove(FAVORITE_SESSION_IDS_KEY)
+        }
+    }
+
     private companion object {
         private val FAVORITE_SESSION_IDS_KEY = stringSetPreferencesKey("FAVORITE_SESSION_IDS_KEY")
         private val PROFILE_KEY = stringPreferencesKey("PROFILE_KEY")

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
@@ -51,6 +52,9 @@ import io.github.droidkaigi.confsched.model.sessions.TimetableSpeaker
 import io.github.droidkaigi.confsched.model.sessions.fake
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+
+const val TimetableItemCardTestTag = "TimetableItemCard"
+const val TimetableItemCardBookmarkButtonTestTag = "TimetableItemCardBookmarkButton"
 
 @Composable
 fun TimetableItemCard(
@@ -77,7 +81,8 @@ fun TimetableItemCard(
                     top = TimetableItemCardDefaults.tagRowTopPadding,
                     bottom = TimetableItemCardDefaults.contentPadding,
                     start = TimetableItemCardDefaults.contentPadding,
-                ),
+                )
+                .testTag(TimetableItemCardTestTag),
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -219,7 +224,11 @@ private fun FavoriteButton(
     isBookmarked: Boolean,
     onClick: () -> Unit,
 ) {
-    TextButton(onClick) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier
+            .testTag(TimetableItemCardBookmarkButtonTestTag),
+    ) {
         if (isBookmarked) {
             Icon(
                 Icons.Filled.Favorite,

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
             implementation(projects.feature.about)
             implementation(projects.feature.eventmap)
             implementation(projects.feature.staff)
+            implementation(projects.feature.favorites)
 
             @OptIn(ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/FavoritesScreenTestGraph.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/FavoritesScreenTestGraph.kt
@@ -1,0 +1,17 @@
+package io.github.droidkaigi.confsched.testing.di
+
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import io.github.droidkaigi.confsched.favorites.FavoritesScreenContext
+import io.github.droidkaigi.confsched.testing.robot.favorites.FavoritesScreenRobot
+
+interface FavoritesScreenTestGraph : FavoritesScreenContext.Factory {
+    val favoritesScreenRobotProvider: Provider<FavoritesScreenRobot>
+
+    @Provides
+    fun provideFavoritesScreenContext(): FavoritesScreenContext {
+        return createFavoritesScreenContext()
+    }
+}
+
+fun createFavoritesScreenTestGraph(): FavoritesScreenTestGraph = createTestAppGraph()

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.kt
@@ -18,7 +18,8 @@ internal interface TestAppGraph :
     TimetableScreenTestGraph,
     AboutScreenTestGraph,
     EventMapScreenTestGraph,
-    StaffScreenTestGraph {
+    StaffScreenTestGraph,
+    FavoritesScreenTestGraph {
 
     @Binds
     val FakeSessionsApiClient.binds: SessionsApiClient

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/favorites/FavoritesScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/favorites/FavoritesScreenRobot.kt
@@ -1,0 +1,128 @@
+package io.github.droidkaigi.confsched.testing.robot.favorites
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import dev.zacsweers.metro.Inject
+import io.github.droidkaigi.confsched.data.sessions.FakeSessionsApiClient
+import io.github.droidkaigi.confsched.data.user.UserDataStore
+import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultErrorFallbackContentTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultSuspenseFallbackContentTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardBookmarkButtonTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableListTestTag
+import io.github.droidkaigi.confsched.favorites.FavoritesScreenContext
+import io.github.droidkaigi.confsched.favorites.FavoritesScreenRoot
+import io.github.droidkaigi.confsched.favorites.FavoritesScreenTestTag
+import io.github.droidkaigi.confsched.favorites.section.FavoritesEmptyViewTestTag
+import io.github.droidkaigi.confsched.model.sessions.TimetableItemId
+import io.github.droidkaigi.confsched.testing.compose.TestDefaultsProvider
+import io.github.droidkaigi.confsched.testing.robot.core.CaptureScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.DefaultCaptureScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.DefaultWaitRobot
+import io.github.droidkaigi.confsched.testing.robot.core.WaitRobot
+import io.github.droidkaigi.confsched.testing.robot.sessions.DefaultTimetableServerRobot
+import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot
+import kotlinx.coroutines.test.TestDispatcher
+
+@Inject
+class FavoritesScreenRobot(
+    private val screenContext: FavoritesScreenContext,
+    private val testDispatcher: TestDispatcher,
+    private val timetableServerRobot: DefaultTimetableServerRobot,
+    private val userDataStore: UserDataStore,
+    captureScreenRobot: DefaultCaptureScreenRobot,
+    waitRobot: DefaultWaitRobot,
+) : CaptureScreenRobot by captureScreenRobot,
+    WaitRobot by waitRobot,
+    TimetableServerRobot by timetableServerRobot {
+
+    context(composeUiTest: ComposeUiTest)
+    fun setupFavoritesScreenContent() {
+        composeUiTest.setContent {
+            with(screenContext) {
+                TestDefaultsProvider(testDispatcher) {
+                    FavoritesScreenRoot(
+                        onTimetableItemClick = {},
+                    )
+                }
+            }
+        }
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkLoadingIndicatorDisplayed() {
+        composeUiTest.onNodeWithTag(DefaultSuspenseFallbackContentTestTag).assertIsDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    suspend fun setupSingleFavoriteSession() {
+        // Set up only the first session as favorite
+        val firstSessionId = FakeSessionsApiClient.defaultSessionIds.first()
+        userDataStore.toggleFavorite(TimetableItemId(firstSessionId))
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    suspend fun setupFavoriteSessions() {
+        // Set up multiple sessions as favorites
+        FakeSessionsApiClient.defaultSessionIds.forEach {
+            userDataStore.toggleFavorite(TimetableItemId(it))
+        }
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickFirstSessionBookmark() {
+        composeUiTest.onAllNodes(hasTestTag(TimetableItemCardBookmarkButtonTestTag))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkEmptyViewDisplayed() {
+        composeUiTest.onNodeWithTag(FavoritesEmptyViewTestTag).assertIsDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListItemsDisplayed() {
+        composeUiTest
+            .onAllNodes(hasTestTag(TimetableListTestTag))
+            .onFirst()
+            .assertIsDisplayed()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkErrorFallbackDisplayed() {
+        composeUiTest.onNodeWithTag(DefaultErrorFallbackContentTestTag).assertExists()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListFirstItemNotDisplayed() {
+        composeUiTest
+            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+            .onFirst()
+            .assertIsNotDisplayed()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun scrollFavorites() {
+        composeUiTest
+            .onNode(hasTestTag(FavoritesScreenTestTag))
+            .performTouchInput {
+                swipeUp(
+                    startY = visibleSize.height * 4F / 5,
+                    endY = visibleSize.height / 5F,
+                )
+            }
+    }
+}

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/favorites/FavoritesScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/favorites/FavoritesScreenRobot.kt
@@ -63,7 +63,6 @@ class FavoritesScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     suspend fun setupSingleFavoriteSession() {
-        // Set up only the first session as favorite
         val firstSessionId = FakeSessionsApiClient.defaultSessionIds.first()
         userDataStore.toggleFavorite(TimetableItemId(firstSessionId))
         waitUntilIdle()
@@ -71,7 +70,6 @@ class FavoritesScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     suspend fun setupFavoriteSessions() {
-        // Set up multiple sessions as favorites
         FakeSessionsApiClient.defaultSessionIds.forEach {
             userDataStore.toggleFavorite(TimetableItemId(it))
         }

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/favorites/FavoritesScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/favorites/FavoritesScreenRobot.kt
@@ -123,4 +123,10 @@ class FavoritesScreenRobot(
                 )
             }
     }
+
+    context(composeUiTest: ComposeUiTest)
+    suspend fun clearFavorites() {
+        userDataStore.clearFavorites()
+        waitUntilIdle()
+    }
 }

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.droidkaigiui.component.AnimatedTextTopAppBar
@@ -35,6 +36,8 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+
+const val FavoritesScreenTestTag = "FavoritesScreenTestTag"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -61,7 +64,8 @@ fun FavoritesScreen(
                 scrollBehavior = scrollBehavior,
             )
         },
-        modifier = modifier,
+        modifier = modifier
+            .testTag(FavoritesScreenTestTag),
     ) { innerPadding ->
         Column(
             modifier = Modifier.padding(innerPadding),

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteEmpty.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteEmpty.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
@@ -25,10 +26,13 @@ import io.github.droidkaigi.confsched.favorites.empty_guide
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
+const val FavoritesEmptyViewTestTag = "FavoritesEmptyViewTestTag"
+
 @Composable
 fun FavoriteEmpty(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .testTag(FavoritesEmptyViewTestTag),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/feature/favorites/src/commonTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
+++ b/feature/favorites/src/commonTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
@@ -37,6 +37,8 @@ class FavoritesScreenTest {
             }
             describe("with single favorite session") {
                 doIt {
+                    // Clear favorites is required because the same UserDataStore instance is used throughout the test class
+                    clearFavorites()
                     setupSingleFavoriteSession()
                 }
                 itShould("display single favorite session") {
@@ -46,8 +48,6 @@ class FavoritesScreenTest {
                 }
                 describe("click first session bookmark") {
                     doIt {
-                        // TODO: UserDataStore data cannot be inherited, so definition is also required here
-                        setupSingleFavoriteSession()
                         clickFirstSessionBookmark()
                     }
                     itShould("display empty view") {
@@ -59,6 +59,8 @@ class FavoritesScreenTest {
             }
             describe("with many favorite sessions") {
                 doIt {
+                    // Clear favorites is required because the same UserDataStore instance is used throughout the test class
+                    clearFavorites()
                     setupFavoriteSessions()
                 }
                 itShould("display multiple favorite sessions") {
@@ -68,8 +70,6 @@ class FavoritesScreenTest {
                 }
                 describe("click first session bookmark") {
                     doIt {
-                        // TODO: UserDataStore data cannot be inherited, so definition is also required here
-                        setupFavoriteSessions()
                         clickFirstSessionBookmark()
                     }
                     itShould("display remaining favorite sessions") {
@@ -80,8 +80,6 @@ class FavoritesScreenTest {
                 }
                 describe("scroll to see more sessions") {
                     doIt {
-                        // TODO: UserDataStore data cannot be inherited, so definition is also required here
-                        setupFavoriteSessions()
                         scrollFavorites()
                     }
                     itShould("display scrolled content") {

--- a/feature/favorites/src/commonTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
+++ b/feature/favorites/src/commonTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
@@ -1,0 +1,117 @@
+package io.github.droidkaigi.confsched.favorites
+
+import androidx.compose.ui.test.runComposeUiTest
+import io.github.droidkaigi.confsched.testing.annotations.ComposeTest
+import io.github.droidkaigi.confsched.testing.annotations.RunWith
+import io.github.droidkaigi.confsched.testing.annotations.UiTestRunner
+import io.github.droidkaigi.confsched.testing.behavior.describeBehaviors
+import io.github.droidkaigi.confsched.testing.behavior.execute
+import io.github.droidkaigi.confsched.testing.di.createFavoritesScreenTestGraph
+import io.github.droidkaigi.confsched.testing.robot.favorites.FavoritesScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.sessions.TimetableServerRobot.ServerStatus
+
+@RunWith(UiTestRunner::class)
+class FavoritesScreenTest {
+    val testAppGraph = createFavoritesScreenTestGraph()
+
+    @ComposeTest
+    fun runTest() {
+        describedBehaviors.forEach { behavior ->
+            val robot = testAppGraph.favoritesScreenRobotProvider()
+            runComposeUiTest {
+                behavior.execute(robot)
+            }
+        }
+    }
+
+    val describedBehaviors = describeBehaviors<FavoritesScreenRobot>("FavoritesScreen") {
+        describe("when server is operational") {
+            doIt {
+                setupTimetableServer(ServerStatus.Operational)
+                setupFavoritesScreenContent()
+            }
+            itShould("show loading indicator") {
+                captureScreenWithChecks {
+                    checkLoadingIndicatorDisplayed()
+                }
+            }
+            describe("with single favorite session") {
+                doIt {
+                    setupSingleFavoriteSession()
+                }
+                itShould("display single favorite session") {
+                    captureScreenWithChecks {
+                        checkTimetableListItemsDisplayed()
+                    }
+                }
+                describe("click first session bookmark") {
+                    doIt {
+                        // TODO: UserDataStore data cannot be inherited, so definition is also required here
+                        setupSingleFavoriteSession()
+                        clickFirstSessionBookmark()
+                    }
+                    itShould("display empty view") {
+                        captureScreenWithChecks {
+                            checkEmptyViewDisplayed()
+                        }
+                    }
+                }
+            }
+            describe("with many favorite sessions") {
+                doIt {
+                    setupFavoriteSessions()
+                }
+                itShould("display multiple favorite sessions") {
+                    captureScreenWithChecks {
+                        checkTimetableListItemsDisplayed()
+                    }
+                }
+                describe("click first session bookmark") {
+                    doIt {
+                        // TODO: UserDataStore data cannot be inherited, so definition is also required here
+                        setupFavoriteSessions()
+                        clickFirstSessionBookmark()
+                    }
+                    itShould("display remaining favorite sessions") {
+                        captureScreenWithChecks {
+                            checkTimetableListItemsDisplayed()
+                        }
+                    }
+                }
+                describe("scroll to see more sessions") {
+                    doIt {
+                        // TODO: UserDataStore data cannot be inherited, so definition is also required here
+                        setupFavoriteSessions()
+                        scrollFavorites()
+                    }
+                    itShould("display scrolled content") {
+                        captureScreenWithChecks {
+                            checkTimetableListFirstItemNotDisplayed()
+                        }
+                    }
+                }
+            }
+        }
+        describe("when server is error") {
+            doIt {
+                setupTimetableServer(ServerStatus.Error)
+                setupFavoritesScreenContent()
+            }
+            itShould("show loading indicator") {
+                captureScreenWithChecks {
+                    checkLoadingIndicatorDisplayed()
+                }
+            }
+            describe("after loading") {
+                doIt {
+                    waitFor5Seconds()
+                }
+                itShould("show error message") {
+                    captureScreenWithChecks {
+                        checkErrorFallbackDisplayed()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue
- close #156

## Overview (Required)
- implemented FavoritesScreenTest based on last year's implementation.
- However, there are some areas where DataStore does not work, so we have implemented workarounds.

## Links
- [TimetableScreenTest example](https://github.com/DroidKaigi/conference-app-2025/blob/main/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt)
- [Last year's implementation](https://github.com/DroidKaigi/conference-app-2024/blob/main/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
