### PR TITLE
fix: FAB's color on timetable item detail.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailFloatingMenu.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailFloatingMenu.kt
@@ -100,6 +100,7 @@ private fun TimetableItemDetailFloatingActionButtonMenu(
     }
 
     val roomTheme = LocalRoomTheme.current
+    // TODO: This color is temporary. We should define a proper color once the official Figma definitions are available.
     val menuItemContainerColor = roomTheme.primaryColor.copy(alpha = 0.5f).compositeOver(Color.Black)
     FloatingActionButtonMenu(
         expanded = expanded,


### PR DESCRIPTION
## Issue
- close #214

## Overview (Required)
- I fixed FAB color on TimetableItemDetailScreen.
  - Since Figma did not have color definitions, I made RoomTheme.primaryColor transparent so that the text would be easier to read.
  - RoomTheme.containerColor was too transparent.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After | Before | After
:--: | :--: | :--: | :--:
<img width="1344" height="2992" alt="Screenshot_20250821_184326" src="https://github.com/user-attachments/assets/8cf7cf0f-d368-4fe7-922f-33c598c14705" /> | <img width="1344" height="2992" alt="Screenshot_20250821_184202" src="https://github.com/user-attachments/assets/bc3049ba-7da4-45d4-a295-c8865c08aa9a" /> | <img width="1344" height="2992" alt="Screenshot_20250821_184332" src="https://github.com/user-attachments/assets/27c7d1d5-c0fd-42ef-a614-014c50ce378c" /> | <img width="1344" height="2992" alt="Screenshot_20250821_184210" src="https://github.com/user-attachments/assets/1c9b8ed2-8b65-40df-8656-bc42264d813b" /> |
<img width="1344" height="2992" alt="Screenshot_20250821_184339" src="https://github.com/user-attachments/assets/34050c55-0e08-4e90-a6ca-63f01e6ca353" /> | <img width="1344" height="2992" alt="Screenshot_20250821_184216" src="https://github.com/user-attachments/assets/55c4b2a2-6a39-432f-9c71-aca302104ef3" /> | <img width="1344" height="2992" alt="Screenshot_20250821_184345" src="https://github.com/user-attachments/assets/5dad0481-27ee-4417-a965-84eb839cc543" /> | <img width="1344" height="2992" alt="Screenshot_20250821_184226" src="https://github.com/user-attachments/assets/cf6b7a20-1114-481b-b662-efc8c713307b" />
| <img width="1344" height="2992" alt="Screenshot_20250821_184352" src="https://github.com/user-attachments/assets/0fedea91-9304-4521-bcf1-a8aa53c71bd9" /> | <img width="1344" height="2992" alt="Screenshot_20250821_184242" src="https://github.com/user-attachments/assets/c09e45ac-d623-4575-89eb-f567d2578992" /> | | |
