### PR TITLE
:wrench: Resolved an issue where iOS and JVM tests were failing.

### DIFF
--- a/core/testing/src/iosMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.ios.kt
+++ b/core/testing/src/iosMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.ios.kt
@@ -6,10 +6,14 @@ import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.createGraph
 import io.github.droidkaigi.confsched.data.DataScope
+import io.github.droidkaigi.confsched.data.about.FakeBuildConfigProvider
+import io.github.droidkaigi.confsched.data.about.FakeLicensesJsonReader
 import io.github.droidkaigi.confsched.data.contributors.DefaultContributorsApiClient
 import io.github.droidkaigi.confsched.data.contributors.DefaultContributorsQueryKey
 import io.github.droidkaigi.confsched.data.core.DataStorePathProducer
 import io.github.droidkaigi.confsched.data.core.defaultJson
+import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapApiClient
+import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapQueryKey
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultTimetableQueryKey
 import io.github.droidkaigi.confsched.data.staff.DefaultStaffApiClient
@@ -20,6 +24,7 @@ import io.github.droidkaigi.confsched.model.contributors.ContributorsQueryKey
 import io.github.droidkaigi.confsched.model.data.FavoriteTimetableIdsSubscriptionKey
 import io.github.droidkaigi.confsched.model.data.FavoriteTimetableItemIdMutationKey
 import io.github.droidkaigi.confsched.model.data.TimetableQueryKey
+import io.github.droidkaigi.confsched.model.eventmap.EventMapQueryKey
 import io.github.droidkaigi.confsched.model.staff.StaffQueryKey
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineDispatcher
@@ -36,6 +41,7 @@ import platform.Foundation.NSUserDomainMask
     excludes = [
         DefaultSessionsApiClient::class,
         DefaultContributorsApiClient::class,
+        DefaultEventMapApiClient::class,
         DefaultStaffApiClient::class,
         CoroutineDispatcher::class,
     ],
@@ -56,6 +62,9 @@ internal interface IosTestAppGraph : TestAppGraph {
     @Binds
     val DefaultContributorsQueryKey.bind: ContributorsQueryKey
 
+    @Binds
+    val DefaultEventMapQueryKey.bind: EventMapQueryKey
+
     @Provides
     fun provideJson(): Json {
         return defaultJson()
@@ -75,6 +84,12 @@ internal interface IosTestAppGraph : TestAppGraph {
             requireNotNull(documentDirectory).path + "/$fileName"
         }
     }
+
+    @Provides
+    fun provideFakeBuildConfigProvider(): FakeBuildConfigProvider = FakeBuildConfigProvider()
+
+    @Provides
+    fun provideFakeLicensesJsonReader(): FakeLicensesJsonReader = FakeLicensesJsonReader()
 }
 
 internal actual fun createTestAppGraph(): TestAppGraph {

--- a/core/testing/src/jvmMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.jvm.kt
+++ b/core/testing/src/jvmMain/kotlin/io/github/droidkaigi/confsched/testing/di/TestAppGraph.jvm.kt
@@ -2,9 +2,13 @@ package io.github.droidkaigi.confsched.testing.di
 
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.createGraph
 import io.github.droidkaigi.confsched.data.DataScope
+import io.github.droidkaigi.confsched.data.about.FakeBuildConfigProvider
+import io.github.droidkaigi.confsched.data.about.FakeLicensesJsonReader
 import io.github.droidkaigi.confsched.data.contributors.DefaultContributorsApiClient
+import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsApiClient
 import io.github.droidkaigi.confsched.data.staff.DefaultStaffApiClient
 import kotlinx.coroutines.CoroutineDispatcher
@@ -16,11 +20,18 @@ import kotlinx.coroutines.CoroutineDispatcher
     excludes = [
         DefaultSessionsApiClient::class,
         DefaultContributorsApiClient::class,
+        DefaultEventMapApiClient::class,
         DefaultStaffApiClient::class,
         CoroutineDispatcher::class,
     ],
 )
-internal interface JvmTestAppGraph : TestAppGraph
+internal interface JvmTestAppGraph : TestAppGraph {
+    @Provides
+    fun provideFakeBuildConfigProvider(): FakeBuildConfigProvider = FakeBuildConfigProvider()
+
+    @Provides
+    fun provideFakeLicensesJsonReader(): FakeLicensesJsonReader = FakeLicensesJsonReader()
+}
 
 internal actual fun createTestAppGraph(): TestAppGraph {
     return createGraph<JvmTestAppGraph>()


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- The necessary descriptions for TestAppGraph on iOS and JVM were missing, causing the test to fail.
- I used the following Gradle command to confirm the failure and that the test passed after the correction.

```
./gradlew cleanTest :feature:about:clean \
  :feature:about:jvmTest \
  :feature:about:iosX64Test \
  :feature:about:iosSimulatorArm64Test --no-configuration-cache

./gradlew cleanTest :feature:eventmap:clean \
  :feature:eventmap:jvmTest \
  :feature:eventmap:iosX64Test \
  :feature:eventmap:iosSimulatorArm64Test --no-configuration-cache
```