### PR TITLE
fix #282 (iOS)remove deprecated --path option from SwiftLint build phase

### DIFF
--- a/app-ios/scripts/xcode-lint.sh
+++ b/app-ios/scripts/xcode-lint.sh
@@ -94,7 +94,7 @@ echo "Running SwiftLint on $FILE_COUNT modified Swift file(s)..."
 # Use --config to specify our configuration file
 echo -e "$FILTERED_FILES" | while IFS= read -r file; do
     if [ -n "$file" ] && [ -f "$file" ]; then
-        "$SWIFTLINT_PATH" lint --config "$SRCROOT/.swiftlint.yml" --quiet --path "$file"
+        "$SWIFTLINT_PATH" lint --config "$SRCROOT/.swiftlint.yml" --quiet "$file"
     fi
 done
 


### PR DESCRIPTION
## Issue
- close #282 

## Overview (Required)
- Fixed a build error in the iOS project caused by using the deprecated `--path` option in the SwiftLint build phase.  
- Removed the `--path` option so that SwiftLint runs successfully.  
- With this change, the iOS project can be built without errors.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img width="400" alt="スクリーンショット 2025-08-22 0 33 04" src="https://github.com/user-attachments/assets/b905b23e-daea-4c50-90cb-c63609580f9e" /> | <img width="400" alt="スクリーンショット 2025-08-22 0 38 52" src="https://github.com/user-attachments/assets/a55c5188-f925-45d6-ad5f-53990b799640" />
