### PR TITLE
:wrench: Fixed an issue where the task would always fail with an OOM error when executing “./gradlew app-shared:assembleSharedXCFramework”.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,17 @@
 # gradle
-org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=3g -Dfile.encoding=UTF-8
-org.gradle.workers.max=2
+org.gradle.jvmargs=-Xmx16g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.workers.max=1
 org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.vfs.watch=false
 # android
 android.useAndroidX=true
 # kotlin
 kotlin.code.style=official
 kotlin.native.cacheKind.iosSimulatorArm64=none
+kotlin.daemon.jvm.options=-Xmx8g
 # roborazzi
 roborazzi.test.record=true
 roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)

- When following the steps described in README.md for app-ios, the output task for the shared KMP Framework always fails with an OOM error.

```shell
Starting a Gradle Daemon, 2 stopped Daemons could not be reused, use --status for details
Configuration on demand is an incubating feature.
Reusing configuration cache.
The Daemon will expire after the build after running out of JVM heap space.
The project memory settings are likely not configured or are configured to an insufficient value.
The daemon will restart for the next build, which may increase subsequent build times.
These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'.
The currently configured max heap space is '5 GiB' and the configured max metaspace is 'unknown'.
For more information on how to set these values, please refer to:
https://docs.gradle.org/9.0.0/userguide/build_environment.html#sec:configuring_jvm_memory
To disable this warning, set 'org.gradle.daemon.performance.disable-logging=true'.

Daemon will be stopped at the end of the build after running out of JVM heap space

java.lang.OutOfMemoryError: Java heap space
    at org.gradle.fileevents.internal.AbstractNativeFileEventFunctions$NativeFileWatcher.executeRunLoop0(Native Method)
    at org.gradle.fileevents.internal.AbstractNativeFileEventFunctions$NativeFileWatcher.executeRunLoop(AbstractNativeFileEventFunctions.java:32)
    at org.gradle.fileevents.internal.AbstractFileEventFunctions$AbstractFileWatcher$1.run(AbstractFileEventFunctions.java:154)

Caught exception: Caught java.lang.OutOfMemoryError with message: Java heap space
Error while receiving file changes

net.rubygrapefruit.platform.NativeException: Caught java.lang.OutOfMemoryError with message: Java heap space
    at org.gradle.fileevents.internal.AbstractNativeFileEventFunctions$NativeFileWatcher.executeRunLoop0(Native Method)
    at org.gradle.fileevents.internal.AbstractNativeFileEventFunctions$NativeFileWatcher.executeRunLoop(AbstractNativeFileEventFunctions.java:32)
    at org.gradle.fileevents.internal.AbstractFileEventFunctions$AbstractFileWatcher$1.run(AbstractFileEventFunctions.java:154)

> Task :app-shared:linkReleaseFrameworkIosArm64 FAILED

e: Compilation failed: Java heap space

 * Source files:
 * Compiler version: 2.2.0
 * Output kind: FRAMEWORK

e: java.lang.OutOfMemoryError: Java heap space
    at org.jetbrains.kotlin.backend.konan.optimizations.DevirtualizationAnalysis$DevirtualizationAnalysisImpl$ConstraintGraphBuilder.addEdge(DevirtualizationAnalysis.kt:846)
    at org.jetbrains.kotlin.backend.konan.optimizations.DevirtualizationAnalysis$DevirtualizationAnalysisImpl$ConstraintGraphBuilder.dfgNodeToConstraintNode(DevirtualizationAnalysis.kt:1186)
    at org.jetbrains.kotlin.backend.konan.optimizations.DevirtualizationAnalysis$DevirtualizationAnalysisImpl$ConstraintGraphBuilder.build(DevirtualizationAnalysis.kt:927)
    at org.jetbrains.kotlin.backend.konan.optimizations.DevirtualizationAnalysis$DevirtualizationAnalysisImpl.buildConstraintGraphPrecursor(DevirtualizationAnalysis.kt:752)
    at org.jetbrains.kotlin.backend.konan.optimizations.DevirtualizationAnalysis$DevirtualizationAnalysisImpl.buildConstraintGraph(DevirtualizationAnalysis.kt:719)
    at org.jetbrains.kotlin.backend.konan.optimizations.DevirtualizationAnalysis$DevirtualizationAnalysisImpl.analyze(DevirtualizationAnalysis.kt:409)
    at org.jetbrains.kotlin.backend.konan.optimizations.DevirtualizationAnalysis.run(DevirtualizationAnalysis.kt:1303)
    at org.jetbrains.kotlin.backend.konan.driver.phases.LTOKt.DevirtualizationAnalysisPhase$lambda$3(LTO.kt:57)
    at org.jetbrains.kotlin.backend.konan.driver.phases.LTOKt$$Lambda/0x00000008016cc670.invoke(Unknown Source)
    at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$createSimpleNamedCompilerPhase$3.phaseBody(PhaseBuilders.kt:78)
    at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$createSimpleNamedCompilerPhase$3.phaseBody(PhaseBuilders.kt:67)
    at org.jetbrains.kotlin.config.phaser.NamedCompilerPhase.invoke(CompilerPhase.kt:102)
    at org.jetbrains.kotlin.backend.common.phaser.PhaseEngine.runPhase(PhaseEngine.kt:64)
    at org.jetbrains.kotlin.backend.konan.driver.phases.TopLevelPhasesKt.runCodegen(TopLevelPhases.kt:494)
    at org.jetbrains.kotlin.backend.konan.driver.phases.TopLevelPhasesKt.runBackendCodegen(TopLevelPhases.kt:448)
    at org.jetbrains.kotlin.backend.konan.driver.phases.TopLevelPhasesKt.compileModule(TopLevelPhases.kt:372)
    at org.jetbrains.kotlin.backend.konan.driver.phases.TopLevelPhasesKt.runBackend$lambda$30$runAfterLowerings(TopLevelPhases.kt:204)
    at org.jetbrains.kotlin.backend.konan.driver.phases.TopLevelPhasesKt.runBackend(TopLevelPhases.kt:229)
    at org.jetbrains.kotlin.backend.konan.driver.DynamicCompilerDriver.produceObjCFramework(DynamicCompilerDriver.kt:82)
    at org.jetbrains.kotlin.backend.konan.driver.DynamicCompilerDriver.run$lambda$2$lambda$1$lambda$0(DynamicCompilerDriver.kt:43)
    at org.jetbrains.kotlin.backend.konan.driver.DynamicCompilerDriver$$Lambda/0x0000000800f937a0.invoke(Unknown Source)
    at org.jetbrains.kotlin.backend.konan.driver.MachineryKt$startTopLevel$topLevelPhase$1.phaseBody(Machinery.kt:60)
    at org.jetbrains.kotlin.backend.konan.driver.MachineryKt$startTopLevel$topLevelPhase$1.phaseBody(Machinery.kt:57)
    at org.jetbrains.kotlin.config.phaser.NamedCompilerPhase.invoke(CompilerPhase.kt:102)
    at org.jetbrains.kotlin.backend.konan.driver.MachineryKt.startTopLevel(Machinery.kt:67)
    at org.jetbrains.kotlin.backend.konan.driver.DynamicCompilerDriver.run(DynamicCompilerDriver.kt:37)
    at org.jetbrains.kotlin.backend.konan.KonanDriver.run(KonanDriver.kt:159)
    at org.jetbrains.kotlin.cli.bc.K2Native.runKonanDriver(K2Native.kt:169)
    at org.jetbrains.kotlin.cli.bc.K2Native.runKonanDriver$default(K2Native.kt:110)
    at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:69)
    at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:36)
    at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:123)

```

- As a result, the following measures were taken, and the task no longer fails midway.

1. Expanded the heap area
2. Increased the heap size on the Kotlin compiler (daemon) side
3. Reduced the number of parallel workers to lower peak memory usage
4. Eliminated the possibility of file monitoring consuming memory
