### PR TITLE
feat(ui): change favorite icon color to room theme color

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
@@ -46,6 +46,7 @@ import io.github.droidkaigi.confsched.droidkaigiui.extension.icon
 import io.github.droidkaigi.confsched.droidkaigiui.extension.roomTheme
 import io.github.droidkaigi.confsched.droidkaigiui.not_bookmarked
 import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
+import io.github.droidkaigi.confsched.model.core.Room
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
 import io.github.droidkaigi.confsched.model.sessions.TimetableSpeaker
 import io.github.droidkaigi.confsched.model.sessions.fake
@@ -224,13 +225,13 @@ private fun FavoriteButton(
             Icon(
                 Icons.Filled.Favorite,
                 contentDescription = stringResource(DroidkaigiuiRes.string.bookmarked),
-                tint = MaterialTheme.colorScheme.primaryFixed,
+                tint = LocalRoomTheme.current.primaryColor,
             )
         } else {
             Icon(
                 Icons.Outlined.FavoriteBorder,
                 contentDescription = stringResource(DroidkaigiuiRes.string.not_bookmarked),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                tint = LocalRoomTheme.current.primaryColor,
             )
         }
     }
@@ -306,10 +307,12 @@ private fun TimetableItemCardPreview_WithError() {
 @Composable
 private fun FavoriteButton() {
     KaigiPreviewContainer {
-        FavoriteButton(
-            isBookmarked = false,
-            onClick = {},
-        )
+        ProvideRoomTheme(TimetableItem.Session.fake().room.roomTheme) {
+            FavoriteButton(
+                isBookmarked = false,
+                onClick = {},
+            )
+        }
     }
 }
 
@@ -317,10 +320,12 @@ private fun FavoriteButton() {
 @Composable
 private fun FavoriteButton_Bookmarked() {
     KaigiPreviewContainer {
-        FavoriteButton(
-            isBookmarked = true,
-            onClick = {},
-        )
+        ProvideRoomTheme(TimetableItem.Session.fake().room.roomTheme) {
+            FavoriteButton(
+                isBookmarked = true,
+                onClick = {},
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Issue
- close #281 

## Overview (Required)
- Changed the favorite icon color to use the RoomTheme color.
- This change applies each room’s theme color to the icon, which is expected to improve UI consistency.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/177baa98-9f23-4d1f-9b30-ced931db4757" width="300" /> | <img src="https://github.com/user-attachments/assets/dbafb20d-5953-4e1c-b52c-c4fd91c86504" width="300" />

