### PR TITLE
fix: The title of session and profile.

### DIFF
--- a/feature/profile/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/profile/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="profile_card_title">プロフィールカード</string>
+    <string name="profile_card_title">Profile Card</string>
     <string name="profile_card_edit_description">会場やSNSで自分を紹介できるプロフィールカードを作ってみましょう！</string>
     <string name="link_example_text">（ex.X、Instagram...）</string>
     <string name="select_theme">テーマ選択</string>

--- a/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
@@ -18,7 +18,7 @@
     <string name="select_language">言語選択</string>
     <string name="japanese">日本語</string>
     <string name="english">English</string>
-    <string name="timetable">タイムテーブル</string>
+    <string name="timetable">Timetable</string>
     <string name="content_description_share">共有</string>
     <string name="content_description_calendar">カレンダー</string>
     <string name="content_description_schedule">スケジュール</string>


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- The titles on the session list screen and profile screen are different from Figma, so I fixed.
  - I think it would be better to use the same font for the favorites and event map, but since there is no definition for it in Figma, I don't fix.

## Links
- Figma: https://www.figma.com/design/1YjyMBNVLEGcHP4W7UNzDE/DroidKaigi-2025-App-UI?node-id=54849-10371&t=x7KR47hmepg3roKC-1

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After | Before | After
:--: | :--: | :--: | :--:
<img width="1344" height="2992" alt="Screenshot_20250822_184835" src="https://github.com/user-attachments/assets/ab17584c-b532-41ce-a4ae-813b65ed7b90" /> | <img width="1344" height="2992" alt="Screenshot_20250822_184203" src="https://github.com/user-attachments/assets/6725efe1-a304-49b7-8bc5-1c6814dd12c1" /> | <img width="1344" height="2992" alt="Screenshot_20250822_184839" src="https://github.com/user-attachments/assets/902b8d69-0d8a-48cf-94d3-9b2e74b3cc08" /> | <img width="1344" height="2992" alt="Screenshot_20250822_184207" src="https://github.com/user-attachments/assets/be359efd-02e1-4518-bed7-ee5a2d874906" />

