### PR TITLE
Add codeInsightSettings.xml

### DIFF
--- a/.idea/codeInsightSettings.xml
+++ b/.idea/codeInsightSettings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="JavaProjectCodeInsightSettings">
+        <excluded-names>
+            <name>java.lang.reflect.Modifier</name>
+            <name>java.nio.file.WatchEvent.Modifier</name>
+            <name>java.lang.module.ModuleDescriptor.Modifier</name>
+            <name>java.lang.module.ModuleDescriptor.Opens.Modifier</name>
+            <name>java.lang.module.ModuleDescriptor.Requires.Modifier</name>
+            <name>java.lang.module.ModuleDescriptor.Exports.Modifier</name>
+            <name>javax.lang.model.element.Modifier</name>
+            <name>android.view.Surface</name>
+            <name>androidx.core.content.pm.ShortcutInfoCompat.Surface</name>
+            <name>org.w3c.dom.Text</name>
+            <name>android.widget.Button</name>
+            <name>android.graphics.drawable.Icon</name>
+            <name>android.inputmethodservice.Keyboard.Row</name>
+            <name>java.time.format.TextStyle</name>
+            <name>org.threeten.bp.format.TextStyle</name>
+            <name>android.text.Layout.Alignment</name>
+            <name>android.widget.GridLayout.Alignment</name>
+            <name>android.graphics.Canvas</name>
+            <name>android.graphics.Color</name>
+            <name>android.graphics.Paint</name>
+        </excluded-names>
+    </component>
+</project>


### PR DESCRIPTION
## Issue
- close #230

## Overview (Required)
To improve development efficiency, I excluded unnecessary items from the IDE’s code completion suggestions.
Compared to [conference-app-2024](https://github.com/DroidKaigi/conference-app-2024/blob/main/.idea/codeInsightSettings.xml), the following items have been added.
```
<name>java.lang.module.ModuleDescriptor.Modifier</name>
<name>java.lang.module.ModuleDescriptor.Opens.Modifier</name>
<name>java.lang.module.ModuleDescriptor.Requires.Modifier</name>
<name>java.lang.module.ModuleDescriptor.Exports.Modifier</name>
<name>javax.lang.model.element.Modifier</name>
```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a66da367-24ff-4887-abdd-9357bf57d218" width="600" /> | <img src="https://github.com/user-attachments/assets/414c2c53-1b3a-4305-bb4a-d22f35815592" width="600" />




## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
