### PR TITLE
Add .editorconfig for Xcode

### DIFF
--- a/app-ios/.editorconfig
+++ b/app-ios/.editorconfig
@@ -1,0 +1,9 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Since Xcode 16 supports EditorConfig, this pull request adds an .editorconfig file.
This would help ensure consistent code style, such as indentation width, across users with different Xcode settings.

## Links
- https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#Source-Editor
