### PR TITLE
fix: add contentWindowInsets to Favorites, Search, and Sponsors screens

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
@@ -64,6 +64,7 @@ fun FavoritesScreen(
                 scrollBehavior = scrollBehavior,
             )
         },
+        contentWindowInsets = WindowInsets(),
         modifier = modifier
             .testTag(FavoritesScreenTestTag),
     ) { innerPadding ->

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.sessions
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -28,6 +29,7 @@ fun SearchScreen(
                 onBackClick = onBackClick,
             )
         },
+        contentWindowInsets = WindowInsets(),
         modifier = modifier,
     ) { paddingValues ->
         Column(

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -63,6 +64,7 @@ fun SponsorsScreen(
                 scrollBehavior = scrollBehavior,
             )
         },
+        contentWindowInsets = WindowInsets(),
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
             LazyVerticalGrid(


### PR DESCRIPTION
## Issue
- close #306
- close #307 
- close #308 

## Overview (Required)
- When displaying FavoritesScreen, SearchScreen, and SponsorsScreen with 3-button navigation, the screen content doesn't extend behind the navigation bar. So fixed it

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f096ade5-283b-4ba8-83b7-921a52d99f42" width="300" /> | <img src="https://github.com/user-attachments/assets/307cce2d-2601-4607-957c-2485cd8c94d2" width="300" />
Before | After
<img src="https://github.com/user-attachments/assets/1a3fa805-0d33-4234-ab3f-f3ff4bfbf592" width="300" /> | <img src="https://github.com/user-attachments/assets/3f7186b4-0543-4f1a-88e6-acbb2fa86d77" width="300" />
Before | After
<img src="https://github.com/user-attachments/assets/8e72ffdb-2281-43ac-bbc6-1096b9677fef" width="300" /> | <img src="https://github.com/user-attachments/assets/357d63dd-04af-4140-b655-e38fce1ea354" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
