### PR TITLE
English descriptions for EventMap

### DIFF
--- a/feature/eventmap/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/eventmap/src/commonMain/composeResources/values-en/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="event_map_description">At DroidKaigi, we also host events beyond the sessions for participants to enjoy. Take the opportunity to connect, share ideas, and fully experience the conference!</string>
+</resources>

--- a/feature/eventmap/src/commonMain/composeResources/values/strings.xml
+++ b/feature/eventmap/src/commonMain/composeResources/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="event_map">EventMap</string>
-    <!-- TODO: Localize -->
     <string name="event_map_description">DroidKaigiでは、セッション以外にも参加者が楽しめるイベントを開催。コミュニケーションや技術交流を通じてカンファレンスを満喫しましょう！</string>
     <string name="read_more">Read More</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #314

## Overview (Required)
- Added English translation for `event_map_description`
- Created `values-en/strings.xml` and placed the translation there

## Links
- Reference: `conference-app-2025/feature/eventmap/src/commonMain/composeResources/values-en/strings.xml`

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/3cbbc655-eba2-458b-a9d3-effbc59dfaf2" width="300" /> | <img src="https://github.com/user-attachments/assets/c5b5b270-d73a-4af4-90a0-bb1ee39a9afd" width="300" />