### PR TITLE
In TimetableItemDetailSummaryCard, apply strike-through style for cancelled session

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/sessions/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/sessions/TimetableItem.kt
@@ -126,6 +126,9 @@ sealed class TimetableItem {
             "https://2024.droidkaigi.jp/en/timetable/${id.value}"
         }
 
+    val isCancelledSession: Boolean
+        get() = message != null
+
     fun getSupportedLangString(isJapaneseLocale: Boolean): String {
         val japanese = if (isJapaneseLocale) "日本語" else "Japanese"
         val english = if (isJapaneseLocale) "英語" else "English"

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailSummaryCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -78,6 +79,7 @@ fun TimetableItemDetailSummaryCard(
             contentDescription = stringResource(SessionsRes.string.content_description_schedule),
             title = stringResource(SessionsRes.string.schedule_title),
             description = timetableItem.formattedDateTimeString,
+            isCancelledSession = timetableItem.isCancelledSession,
         )
         Spacer(Modifier.height(8.dp))
         SummaryCardText(
@@ -90,6 +92,7 @@ fun TimetableItemDetailSummaryCard(
             contentDescription = stringResource(SessionsRes.string.content_description_location),
             title = stringResource(SessionsRes.string.location_title),
             description = timetableItem.room.nameAndFloor,
+            isCancelledSession = timetableItem.isCancelledSession,
         )
         Spacer(Modifier.height(8.dp))
         SummaryCardText(
@@ -104,6 +107,7 @@ fun TimetableItemDetailSummaryCard(
             description = timetableItem.getSupportedLangString(
                 getDefaultLocale() == Locale.JAPAN,
             ),
+            isCancelledSession = timetableItem.isCancelledSession,
         )
         Spacer(Modifier.height(8.dp))
         SummaryCardText(
@@ -116,6 +120,7 @@ fun TimetableItemDetailSummaryCard(
             contentDescription = stringResource(SessionsRes.string.content_description_category),
             title = stringResource(SessionsRes.string.category_title),
             description = timetableItem.category.title.currentLangTitle,
+            isCancelledSession = timetableItem.isCancelledSession,
         )
     }
 }
@@ -126,6 +131,7 @@ private fun SummaryCardText(
     contentDescription: String,
     title: String,
     description: String,
+    isCancelledSession: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val iconInlineContentId = "icon"
@@ -135,6 +141,7 @@ private fun SummaryCardText(
     val annotatedString = createSummaryCardTextAnnotatedString(
         title = title,
         description = description,
+        isCancelledSession = isCancelledSession,
         iconInlineContentId = iconInlineContentId,
         spacer8dpInlineContentId = spacer8dpInlineContentId,
         spacer12dpInlineContentId = spacer12dpInlineContentId,
@@ -163,6 +170,7 @@ private fun SummaryCardText(
 private fun createSummaryCardTextAnnotatedString(
     title: String,
     description: String,
+    isCancelledSession: Boolean,
     iconInlineContentId: String,
     spacer8dpInlineContentId: String,
     spacer12dpInlineContentId: String,
@@ -190,6 +198,7 @@ private fun createSummaryCardTextAnnotatedString(
                 fontFamily = MaterialTheme.typography.bodyMedium.fontFamily,
                 fontStyle = MaterialTheme.typography.bodyMedium.fontStyle,
                 fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                textDecoration = if (isCancelledSession) TextDecoration.LineThrough else null,
             ),
         ) {
             append(description)


### PR DESCRIPTION
## Issue
- close #315 

## Overview (Required)
- For the cancelled session, the strike-through style is applied for description's text style.

## Links
- [Figma](https://www.figma.com/design/1YjyMBNVLEGcHP4W7UNzDE/DroidKaigi-2025-App-UI?node-id=54901-56792&t=rLcISEDVDKC4bFk3-4)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/eba95425-ed63-4d64-83f6-e33a44955c5b" width="300" /> | <img src="https://github.com/user-attachments/assets/af7c127f-2283-455c-b12c-2208e40238b3" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
