### PR TITLE
fix: TimetableList and navigation bar overlap when searching

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableList.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableList.kt
@@ -7,8 +7,11 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -27,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiWindowSizeClassConstants
 import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableTimeSlot
+import io.github.droidkaigi.confsched.droidkaigiui.extension.plus
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
 import io.github.droidkaigi.confsched.model.sessions.TimetableItemId
 import io.github.droidkaigi.confsched.model.sessions.fake
@@ -57,7 +61,7 @@ fun TimetableList(
         LazyColumn(
             state = lazyListState,
             verticalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = contentPadding,
+            contentPadding = contentPadding + WindowInsets.navigationBars.asPaddingValues(),
             modifier = modifier,
         ) {
             itemsIndexed(


### PR DESCRIPTION
## Issue
- close #327 

## Overview (Required)
- Added a spacer to the search results list to prevent it from overlapping with the navigation bar.


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f458e8ac-1342-48e0-80bc-34c290cc2bfa" width="300" /> | <img src="https://github.com/user-attachments/assets/054e40b1-bf70-4361-96fe-55e0ca637218" width="300" />

