### PR TITLE
fix: Timetable Item Detail Screen's bottom spacing.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched.sessions
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeGestures
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,6 +14,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
+import io.github.droidkaigi.confsched.droidkaigiui.extension.plus
 import io.github.droidkaigi.confsched.droidkaigiui.extension.roomTheme
 import io.github.droidkaigi.confsched.model.core.Lang
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
@@ -62,12 +64,12 @@ fun TimetableItemDetailScreen(
             },
             contentWindowInsets = WindowInsets(),
             modifier = modifier,
-        ) { innerPadding ->
+        ) { contentPadding ->
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(innerPadding)
                     .testTag(TimetableItemDetailScreenLazyColumnTestTag),
+                contentPadding = contentPadding + WindowInsets.navigationBars.asPaddingValues(),
             ) {
                 item {
                     TimetableItemDetailHeadline(


### PR DESCRIPTION
## Issue
- nothing
  - related to: https://github.com/DroidKaigi/conference-app-2025/issues/327

## Overview (Required)
- The bottom of the Timetable Item Detail Screen overlapped with the navigation bar, so I fixed the padding.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img width="1344" height="2992" alt="Screenshot_20250825_184933" src="https://github.com/user-attachments/assets/3186fecf-760e-4a83-ae77-8a9118f1e7de" /> | <img width="1344" height="2992" alt="Screenshot_20250825_185012" src="https://github.com/user-attachments/assets/fd23b132-d399-4a61-9a22-127167ddef1e" />
