### PR TITLE
feat: add preview for EventMapScreen

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -68,7 +68,7 @@ private fun EventMapScreenPreview() {
         EventMapScreen(
             uiState = EventMapUiState(
                 events = EventMapEvent.Companion.fakes(),
-                selectedFloor = FloorLevel.Ground
+                selectedFloor = FloorLevel.Ground,
             ),
             onSelectFloor = {},
             onClickReadMore = {},


### PR DESCRIPTION
## Issue
- close #345

## Overview (Required)
-  Since the preview feature was missing in the EventMapScreen, I have implemented it.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
