### PR TITLE
Fix Roborazzi test failure

### DIFF
--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/settings/SettingsScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/settings/SettingsScreenRobot.kt
@@ -55,7 +55,7 @@ class SettingsScreenRobot(
             displayName = "Roboto Medium",
         ),
         SystemDefault(
-            displayName = "System Default",
+            displayName = "Default",
         ),
     }
 


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Fixed Roborazzi screenshot test failures that were occurring in CI
    - The cause is probably that the SystemDefault display name value was changed. in #348

## Links
-  https://github.com/DroidKaigi/conference-app-2025/pull/348/files#diff-ebd4787068cc5c67a7648ca55dbf7417744498050f38ca5bd42c73a95410cbf6

## Screenshot (Optional if screenshot test is present or unrelated to UI)
- Local execution result

Before | After
:--: | :--:
<img width="1081" height="612" alt="スクリーンショット 2025-08-25 23 11 36" src="https://github.com/user-attachments/assets/fefc208c-32aa-4b28-adb3-fadb0cf2c7cf" /> | <img width="1072" height="186" alt="スクリーンショット 2025-08-25 23 13 31" src="https://github.com/user-attachments/assets/a1006851-58fa-45cd-9143-2341dc42ce80" />

