### PR TITLE
fix: When the font size is large, the date string overflows.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -120,7 +120,7 @@ fun TimetableScreen(
                                     inactiveContainerColor = MaterialTheme.colorScheme.surface,
                                 ),
                                 selected = selectedDay == droidKaigi2025Day,
-                                modifier = Modifier.width(TimetableDefaults.dayTabWidth)
+                                modifier = Modifier.width(TimetableDefaults.dayTabWidth),
                             ) {
                                 Text(droidKaigi2025Day.monthAndDay())
                             }


### PR DESCRIPTION
## Issue
- close #280

## Overview (Required)
- Fixed an issue where the date string would overflow when the font size was large.
- This was achieved by removing the height specification for the “segment button.”

## Links
- None

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/fe7f236b-af7b-4e49-8b61-ab56dc4f4495" width="300" /> | <img src="https://github.com/user-attachments/assets/769411c9-054e-4b19-8962-f9e12179b20e" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
