### PR TITLE
fixed: Normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+# Normalize line endings to LF for Kotlin files
+*.kt text eol=lf


### PR DESCRIPTION
## Issue
- close none

## Overview (Required)
Added a setting to .gitattributes to normalize line endings for Kotlin files to LF.
### Reason
When developing on Windows, running `./gradlew spotlessApply` formats all Kotlin files and changes the line endings to CRLF.
### Solution
This issue is likely caused by a missing line ending configuration in Spotless.   
However, since this could also happen with other file generation or formatting tools, I am proposing adding this rule to `.gitattributes` to ensure consistency.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
