### PR TITLE
Remove unnecessary Gradle properties to improve build performance and update iOS build setup instructions

### DIFF
--- a/app-ios/Native/Package.swift
+++ b/app-ios/Native/Package.swift
@@ -226,7 +226,7 @@ let package = Package(
                 .plugin(name: "SwiftGenPlugin", package: "SwiftGenPlugin")
             ]
         ),
-        // Please run ./gradlew app-shared:assembleSharedXCFramework first
+        // Please run ./gradlew app-shared:assembleSharedDebugXCFramework first
         .binaryTarget(name: "KMPFramework", path: "../../app-shared/build/XCFrameworks/debug/shared.xcframework"),
     ],
     swiftLanguageModes: [.v6]

--- a/app-ios/README.md
+++ b/app-ios/README.md
@@ -149,7 +149,7 @@ git clone https://github.com/DroidKaigi/conference-app-2025.git
 
 2. Assemble the shared KMP framework:
 ```bash
-./gradlew app-shared:assembleSharedXCFramework
+./gradlew app-shared:assembleSharedDebugXCFramework
 ```
 
 3. Setup the project:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 # gradle
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=3g -Dfile.encoding=UTF-8
-org.gradle.workers.max=2
 org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
 org.gradle.caching=true


### PR DESCRIPTION
## Issue
- close #334

## Overview (Required)
- Replace `assembleSharedXCFramework` with `assembleSharedDebugXCFramework` in iOS instructions and code comments, since we don't need to build the release XCFramework during development.
- Remove `org.gradle.workers.max=2` from `gradle.properties` because contributors typically don't need to build the release XCFramework.
  - @ry-itto: When releasing the iOS app, please generate the release XCFramework by running:
    ```bash
    ./gradlew app-shared:assembleSharedReleaseXCFramework --max-workers=1
    ```
    This avoids the OOM build failure reported in #285.