### PR TITLE
feat: Improve usability by allowing only single selection on Favorite…

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
@@ -16,8 +16,6 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import soil.query.compose.rememberMutation
 
-private const val MIN_FILTERS_TO_DESELECT = 2
-
 @Composable
 context(screenContext: FavoritesScreenContext)
 fun favoritesScreenPresenter(
@@ -40,23 +38,13 @@ fun favoritesScreenPresenter(
                 selectedDayFilters = emptySet()
             }
 
-            FavoritesScreenEvent.FilterDay1,
-            FavoritesScreenEvent.FilterDay2,
-            -> {
+            FavoritesScreenEvent.FilterDay1 -> {
                 allFilterSelected = false
-
-                val dayType = if (event is FavoritesScreenEvent.FilterDay1) {
-                    DroidKaigi2025Day.ConferenceDay1
-                } else {
-                    DroidKaigi2025Day.ConferenceDay2
-                }
-
-                selectedDayFilters =
-                    if (selectedDayFilters.contains(dayType) && selectedDayFilters.size >= MIN_FILTERS_TO_DESELECT) {
-                        selectedDayFilters - dayType
-                    } else {
-                        selectedDayFilters + dayType
-                    }
+                selectedDayFilters = setOf(DroidKaigi2025Day.ConferenceDay1)
+            }
+            FavoritesScreenEvent.FilterDay2 -> {
+                allFilterSelected = false
+                selectedDayFilters = setOf(DroidKaigi2025Day.ConferenceDay2)
             }
         }
     }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Under the current specification, the ability to select multiple dates results in poor usability. To select only one date when multiple are already selected, the user must first select "All" (to clear the selection) or deselect both dates manually. To improve the usability of single-date selection, we will disable the ability to select multiple dates.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/b9642269-9686-4a20-863a-f788cb35ae13" width="300" > | <video src="https://github.com/user-attachments/assets/dcc64b22-cc63-4274-925f-a466a7c3ab2e" width="300" >