### PR TITLE
Match ProfileCardUser fonts to figma design

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.designsystem.theme.changoFontFamily
+import io.github.droidkaigi.confsched.designsystem.theme.robotoRegularFontFamily
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.model.profile.ProfileCardTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -48,11 +50,13 @@ fun ProfileCardUser(
             text = occupation,
             style = MaterialTheme.typography.bodyMedium,
             color = if (isDarkTheme) Color.White else Color.Black,
+            fontFamily = robotoRegularFontFamily()
         )
         Text(
             text = userName,
             style = MaterialTheme.typography.headlineSmall,
             color = if (isDarkTheme) Color.White else Color.Black,
+            fontFamily = changoFontFamily()
         )
     }
 }


### PR DESCRIPTION
## Issue
- close #359

## Overview (Required)
- Fixed the font for occupation and username in ProfileCardUser to a fixed value.

## Links
- Figma
https://www.figma.com/design/1YjyMBNVLEGcHP4W7UNzDE/DroidKaigi-2025-App-UI?node-id=64329-10468&t=xqKOkYNx8r9ES0VJ-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
For example, when Chango is selected.
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a231fc29-819c-4ab5-b0d1-f9d3f82dcddd" width="300" /> | <img src="https://github.com/user-attachments/assets/7db0b94a-4d63-4480-99be-e429a972688d" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
