### PR TITLE
#121 add "get sessions" feature by app intent

### DIFF
--- a/app-ios/App/AppShortcuts.xcstrings
+++ b/app-ios/App/AppShortcuts.xcstrings
@@ -1,0 +1,48 @@
+{
+  "sourceLanguage" : "ja",
+  "strings" : {
+    "${applicationName}で指定日のセッションを取得" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "Get sessions at a specific date for ${applicationName}"
+            ]
+          }
+        },
+        "ja" : {
+          "stringSet" : {
+            "state" : "new",
+            "values" : [
+              "${applicationName}で指定日のセッションを取得"
+            ]
+          }
+        }
+      }
+    },
+    "${applicationName}で現在のセッションを取得" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "Get ongoing sessions for ${applicationName}"
+            ]
+          }
+        },
+        "ja" : {
+          "stringSet" : {
+            "state" : "new",
+            "values" : [
+              "${applicationName}で現在のセッションを取得"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/app-ios/App/AppShortcuts.xcstrings
+++ b/app-ios/App/AppShortcuts.xcstrings
@@ -1,14 +1,14 @@
 {
   "sourceLanguage" : "ja",
   "strings" : {
-    "${applicationName}で指定日のセッションを取得" : {
+    "${applicationName}で指定日時のセッションを取得" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringSet" : {
             "state" : "translated",
             "values" : [
-              "Get sessions at a specific date for ${applicationName}"
+              "Get sessions at a specific date and time for ${applicationName}"
             ]
           }
         },
@@ -16,7 +16,7 @@
           "stringSet" : {
             "state" : "new",
             "values" : [
-              "${applicationName}で指定日のセッションを取得"
+              "${applicationName}で指定日時のセッションを取得"
             ]
           }
         }

--- a/app-ios/App/Intents/ConferenceAppShortcutsProvider.swift
+++ b/app-ios/App/Intents/ConferenceAppShortcutsProvider.swift
@@ -3,12 +3,12 @@ import AppIntents
 struct ConferenceAppShortcutsProvider: AppShortcutsProvider {
     @AppShortcutsBuilder static var appShortcuts: [AppShortcut] {
         AppShortcut(
-            intent: GetSessionsAtDateIntent(),
+            intent: GetSessionsAtDateTimeIntent(),
             phrases: [
-                "\(.applicationName)で指定日のセッションを取得"
+                "\(.applicationName)で指定日時のセッションを取得"
             ],
             shortTitle: "Get sessions",
-            systemImageName: "swift",
+            systemImageName: "calendar",
         )
         AppShortcut(
             intent: GetOngoingSessionsIntent(),
@@ -16,7 +16,7 @@ struct ConferenceAppShortcutsProvider: AppShortcutsProvider {
                 "\(.applicationName)で現在のセッションを取得"
             ],
             shortTitle: "Get ongoing sessions",
-            systemImageName: "swift",
+            systemImageName: "calendar",
         )
     }
 

--- a/app-ios/App/Intents/ConferenceAppShortcutsProvider.swift
+++ b/app-ios/App/Intents/ConferenceAppShortcutsProvider.swift
@@ -1,0 +1,24 @@
+import AppIntents
+
+struct ConferenceAppShortcutsProvider: AppShortcutsProvider {
+    @AppShortcutsBuilder static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: GetSessionsAtDateIntent(),
+            phrases: [
+                "\(.applicationName)で指定日のセッションを取得"
+            ],
+            shortTitle: "Get sessions",
+            systemImageName: "swift",
+        )
+        AppShortcut(
+            intent: GetOngoingSessionsIntent(),
+            phrases: [
+                "\(.applicationName)で現在のセッションを取得"
+            ],
+            shortTitle: "Get ongoing sessions",
+            systemImageName: "swift",
+        )
+    }
+
+    static var shortcutTileColor: ShortcutTileColor { .orange }
+}

--- a/app-ios/App/Intents/GetOngoingSessionsIntent.swift
+++ b/app-ios/App/Intents/GetOngoingSessionsIntent.swift
@@ -1,0 +1,22 @@
+import AppIntents
+import Foundation
+
+struct GetOngoingSessionsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get ongoing sessions"
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<[SessionEntity]> & ProvidesDialog {
+        let sessions: [SessionEntity] = try await SessionsQuery().suggestedEntities()
+        let now = Date.now
+        let ongoingSessions = sessions.filter { $0.startTime <= now && now <= $0.endTime }
+
+        let dialog: IntentDialog
+        if ongoingSessions.isEmpty {
+            dialog = IntentDialog("Not found ongoing session")
+        } else {
+            let titles = ongoingSessions.map { $0.title }.joined(separator: ", ")
+            dialog = IntentDialog("Ongoing sessions:\(titles)")
+        }
+        return .result(value: ongoingSessions, dialog: dialog)
+    }
+}

--- a/app-ios/App/Intents/GetOngoingSessionsIntent.swift
+++ b/app-ios/App/Intents/GetOngoingSessionsIntent.swift
@@ -15,7 +15,7 @@ struct GetOngoingSessionsIntent: AppIntent {
             dialog = IntentDialog("Not found ongoing session")
         } else {
             let titles = ongoingSessions.map { $0.title }.joined(separator: ", ")
-            dialog = IntentDialog("Ongoing sessions:\(titles)")
+            dialog = IntentDialog("Ongoing sessions: \(titles)")
         }
         return .result(value: ongoingSessions, dialog: dialog)
     }

--- a/app-ios/App/Intents/GetSessionsAtDateIntent.swift
+++ b/app-ios/App/Intents/GetSessionsAtDateIntent.swift
@@ -1,0 +1,25 @@
+import AppIntents
+import Foundation
+
+struct GetSessionsAtDateIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get sessions at specific date"
+
+    @Parameter(title: "date")
+    var date: Date
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<[SessionEntity]> & ProvidesDialog {
+        let sessions: [SessionEntity] = try await SessionsQuery().suggestedEntities()
+
+        let targetSessions = sessions.filter { $0.startTime <= date && date <= $0.endTime }
+
+        let dialog: IntentDialog
+        if targetSessions.isEmpty {
+            dialog = IntentDialog("Not found sessions")
+        } else {
+            let titles = targetSessions.map { $0.title }.joined(separator: ", ")
+            dialog = IntentDialog("Session titles: \(titles)")
+        }
+        return .result(value: targetSessions, dialog: dialog)
+    }
+}

--- a/app-ios/App/Intents/GetSessionsAtDateTimeIntent.swift
+++ b/app-ios/App/Intents/GetSessionsAtDateTimeIntent.swift
@@ -1,8 +1,8 @@
 import AppIntents
 import Foundation
 
-struct GetSessionsAtDateIntent: AppIntent {
-    static var title: LocalizedStringResource = "Get sessions at specific date"
+struct GetSessionsAtDateTimeIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get sessions at specific date and time"
 
     @Parameter(title: "date")
     var date: Date

--- a/app-ios/App/Intents/SessionEntity.swift
+++ b/app-ios/App/Intents/SessionEntity.swift
@@ -1,0 +1,34 @@
+import AppIntents
+import Foundation
+import Model
+import Root
+
+struct SessionEntity: AppEntity {
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        "Session"
+    }
+
+    var id: String
+    var title: String
+    var startTime: Date
+    var endTime: Date
+    var room: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "session title: \(title)",
+            subtitle:
+                "\(room) | \(startTime.formatted(date: .omitted, time: .shortened)) - \(endTime.formatted(date: .omitted, time: .shortened))"
+        )
+    }
+
+    static var defaultQuery = SessionsQuery()
+
+    init(from session: any Model.TimetableItem) {
+        self.id = session.id.value
+        self.title = session.title.jaTitle.isEmpty ? session.title.enTitle : session.title.jaTitle
+        self.startTime = session.startsAt
+        self.endTime = session.endsAt
+        self.room = session.room.name.jaTitle.isEmpty ? session.room.name.enTitle : session.room.name.jaTitle
+    }
+}

--- a/app-ios/App/Intents/SessionsQuery.swift
+++ b/app-ios/App/Intents/SessionsQuery.swift
@@ -10,7 +10,7 @@ private struct LoadSessions {
         let firstItem = await flow.first(where: { _ in true })
         guard let firstItem else { return [] }
         let timetable = Model.Timetable(from: firstItem)
-        let sessions = timetable.timetableItems.compactMap { item -> SessionEntity in
+        let sessions = timetable.timetableItems.map { item -> SessionEntity in
             .init(from: item)
         }
         return sessions

--- a/app-ios/App/Intents/SessionsQuery.swift
+++ b/app-ios/App/Intents/SessionsQuery.swift
@@ -1,0 +1,31 @@
+import AppIntents
+import Foundation
+import Model
+import Root
+
+private struct LoadSessions {
+    func callAsFunction() async -> [SessionEntity] {
+        let flow = KMPDependencyProvider.shared.appGraph.sessionsRepository
+            .timetableFlow()
+        let firstItem = await flow.first(where: { _ in true })
+        guard let firstItem else { return [] }
+        let timetable = Model.Timetable(from: firstItem)
+        let sessions = timetable.timetableItems.compactMap { item -> SessionEntity in
+            .init(from: item)
+        }
+        return sessions
+    }
+}
+
+struct SessionsQuery: EntityQuery {
+    private let loadSessions = LoadSessions()
+
+    func entities(for identifiers: [String]) async throws -> [SessionEntity] {
+        let all = await loadSessions()
+        return all.filter { identifiers.contains($0.id) }
+    }
+
+    func suggestedEntities() async throws -> [SessionEntity] {
+        await loadSessions()
+    }
+}

--- a/app-ios/App/Localizable.xcstrings
+++ b/app-ios/App/Localizable.xcstrings
@@ -115,7 +115,7 @@
         }
       }
     },
-    "Ongoing sessions:%@" : {
+    "Ongoing sessions: %@" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/app-ios/App/Localizable.xcstrings
+++ b/app-ios/App/Localizable.xcstrings
@@ -67,18 +67,18 @@
         }
       }
     },
-    "Get sessions at specific date" : {
+    "Get sessions at specific date and time" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Get sessions at specific date"
+            "value" : "Get sessions at specific date and time"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "指定日のセッションの取得"
+            "value" : "指定日時のセッションの取得"
           }
         }
       }

--- a/app-ios/App/Localizable.xcstrings
+++ b/app-ios/App/Localizable.xcstrings
@@ -1,0 +1,184 @@
+{
+  "sourceLanguage" : "ja",
+  "strings" : {
+    "%@ | %@ - %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ | %2$@ - %3$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ | %2$@ - %3$@"
+          }
+        }
+      }
+    },
+    "date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日時"
+          }
+        }
+      }
+    },
+    "Get ongoing sessions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get ongoing sessions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のセッションの取得"
+          }
+        }
+      }
+    },
+    "Get sessions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get sessions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッションの取得"
+          }
+        }
+      }
+    },
+    "Get sessions at specific date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get sessions at specific date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指定日のセッションの取得"
+          }
+        }
+      }
+    },
+    "Not found ongoing session" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not found ongoing session"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在セッションはありません"
+          }
+        }
+      }
+    },
+    "Not found sessions" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not found sessions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッションはありません"
+          }
+        }
+      }
+    },
+    "Ongoing sessions:%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ongoing sessions: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のセッション：%@"
+          }
+        }
+      }
+    },
+    "Session" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッション"
+          }
+        }
+      }
+    },
+    "session title: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session title: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッションのタイトル：%@"
+          }
+        }
+      }
+    },
+    "Session titles: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session titles: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッションのタイトル：%@"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/app-ios/Native/Sources/Root/KMPConverters.swift
+++ b/app-ios/Native/Sources/Root/KMPConverters.swift
@@ -249,7 +249,7 @@ extension Model.TimetableItemWithFavorite {
 // MARK: - Timetable Converters
 
 extension Model.Timetable {
-    init(from shared: shared.Timetable) {
+    public init(from shared: shared.Timetable) {
         let timetableItems: [any Model.TimetableItem] = shared.timetableItems.map { item in
             if let session = item as? shared.TimetableItem.Session {
                 return Model.TimetableItemSession(from: session)


### PR DESCRIPTION
## Issue
- close #121 

## Overview (Required)
This PR implements App Intents to retrieve sessions, addressing issue #121.

- Added GetOngoingSessionsIntent to fetch sessions happening right now.
- Added GetSessionsAtDateIntent to fetch sessions at a specific date.
- Introduced ConferenceAppShortcutsProvider for Siri/Shortcuts integration.
- Improves real-time engagement by enabling quick voice or shortcut access to sessions.

## Movie
Add shortcut movie | Call AppIntent by AppShortcuts
:--: | :--:
<video src="https://github.com/user-attachments/assets/3375b4c1-a505-4158-ab28-84d245b4bf00" width="300" > | <video src="https://github.com/user-attachments/assets/3cf362fe-2cac-41a1-9b6d-35295ffc12a2" width="300" >
