### PR TITLE
:wrench: We have made corrections to ensure StaffScreen displays correctly.

### DIFF
--- a/app-ios/Native/Sources/Root/KMPConverters.swift
+++ b/app-ios/Native/Sources/Root/KMPConverters.swift
@@ -351,13 +351,13 @@ extension Model.Staff {
     init(from shared: shared.Staff) {
         // Use FileManager URL as a safe fallback
         let fallbackURL = URL(fileURLWithPath: "/")
-        let iconURL = URL(string: shared.icon) ?? fallbackURL
+        let iconURL = URL(string: shared.iconUrl) ?? fallbackURL
 
         self.init(
-            id: shared.id,
-            name: shared.name,
+            id: String(shared.id),
+            name: shared.username,
             iconUrl: iconURL,
-            profileUrl: shared.profileUrl.flatMap { URL(string: $0) },
+            profileUrl: URL(string: shared.profileUrl),
             role: nil  // KMP Staff doesn't have role field
         )
     }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/DefaultStaffApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/DefaultStaffApiClient.kt
@@ -36,8 +36,8 @@ public class DefaultStaffApiClient(
 private fun StaffItemResponse.toStaff(): Staff {
     return Staff(
         id = id,
-        name = name,
-        icon = icon,
+        username = username,
+        iconUrl = iconUrl,
         profileUrl = profileUrl,
     )
 }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/response/StaffResponse.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/response/StaffResponse.kt
@@ -9,8 +9,8 @@ public data class StaffResponse(
 
 @Serializable
 public data class StaffItemResponse(
-    val id: String,
-    val name: String,
-    val icon: String,
-    val profileUrl: String? = null,
+    val id: Long,
+    val username: String,
+    val profileUrl: String,
+    val iconUrl: String,
 )

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/staff/Staff.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/staff/Staff.kt
@@ -4,10 +4,10 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 data class Staff(
-    val id: String,
-    val name: String,
-    val icon: String,
-    val profileUrl: String?,
+    val id: Long,
+    val username: String,
+    val profileUrl: String,
+    val iconUrl: String,
 ) {
     companion object
 }
@@ -15,9 +15,9 @@ data class Staff(
 fun Staff.Companion.fakes(): PersistentList<Staff> {
     return (1..20).map {
         Staff(
-            id = it.toString(),
-            name = "username $it",
-            icon = "https://placehold.jp/150x150.png",
+            id = it.toLong(),
+            username = "username $it",
+            iconUrl = "https://placehold.jp/150x150.png",
             profileUrl = "https://developer.android.com/",
         )
     }.toPersistentList()

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/staff/StaffScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/staff/StaffScreenRobot.kt
@@ -95,7 +95,7 @@ class StaffScreenRobot(
                 )
                 .assertExists()
                 .assertIsDisplayed()
-                .assertContentDescriptionEquals(staff.name)
+                .assertContentDescriptionEquals(staff.username)
 
             composeUiTest
                 .onNodeWithTag(
@@ -104,7 +104,7 @@ class StaffScreenRobot(
                 )
                 .assertExists()
                 .assertIsDisplayed()
-                .assertTextEquals(staff.name)
+                .assertTextEquals(staff.username)
         }
     }
 

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
@@ -50,13 +50,13 @@ fun ProfileCardUser(
             text = occupation,
             style = MaterialTheme.typography.bodyMedium,
             color = if (isDarkTheme) Color.White else Color.Black,
-            fontFamily = robotoRegularFontFamily()
+            fontFamily = robotoRegularFontFamily(),
         )
         Text(
             text = userName,
             style = MaterialTheme.typography.headlineSmall,
             color = if (isDarkTheme) Color.White else Color.Black,
-            fontFamily = changoFontFamily()
+            fontFamily = changoFontFamily(),
         )
     }
 }

--- a/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/component/StaffItem.kt
+++ b/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/component/StaffItem.kt
@@ -40,7 +40,7 @@ fun StaffItem(
 ) {
     Row(
         modifier = modifier
-            .clickable(enabled = !staff.profileUrl.isNullOrBlank()) {
+            .clickable(enabled = staff.profileUrl.isNotBlank()) {
                 onStaffItemClick()
             }
             .padding(horizontal = 16.dp, vertical = 10.dp),
@@ -50,9 +50,9 @@ fun StaffItem(
         Image(
             painter = previewOverridePainter(
                 previewPainter = { rememberVectorPainter(image = Icons.Default.Person) },
-                painter = { rememberAsyncImagePainter(staff.icon) },
+                painter = { rememberAsyncImagePainter(staff.iconUrl) },
             ),
-            contentDescription = staff.name,
+            contentDescription = staff.username,
             modifier = Modifier
                 .size(52.dp)
                 .clip(staffIconShape)
@@ -64,7 +64,7 @@ fun StaffItem(
                 .testTag(StaffItemImageTestTag.plus(staff.id)),
         )
         Text(
-            text = staff.name,
+            text = staff.username,
             style = MaterialTheme.typography.bodyLarge,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
## Issue
- close #386

## Overview (Required)
- The Staff type had changed from last year, causing it to no longer match the Web API type.
- By modifying it to match last year's version, the Staff screen now displays correctly.

## Links
- https://github.com/DroidKaigi/conference-app-2024/blob/57c38a76beb5b75edc9220833162e1257f40ac06/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/response/StaffResponse.kt

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/be1b0035-dc96-494e-8759-cd4f67f78c08" width="300" > | <video src="https://github.com/user-attachments/assets/1a82cede-a9e5-474d-8519-dbf049e4a658" width="300" >