### PR TITLE
[CI] Ensure KMPConverters.swift builds by adding core/model path check

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'app-ios/**'
       - 'app-shared/**'
+      - 'core/model/**'
       - '.github/workflows/ios-build.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'app-ios/**'
       - 'app-shared/**'
+      - 'core/model/**'
       - '.github/workflows/ios-build.yml'
 
 concurrency:


### PR DESCRIPTION
## Issue
None

## Overview (Required)
- In #335, an iOS build check workflow was added.
- However, it is only triggered when files under the `app-shared` directory are changed.
- This can cause build failures due to unnoticed model class changes.
- To prevent this, I added the `core/model` path to the workflow.