### PR TITLE
#325 Keep library name from being omitted

### DIFF
--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/LicensesScreen.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/LicensesScreen.kt
@@ -1,16 +1,23 @@
 package io.github.droidkaigi.confsched.about
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+import com.mikepenz.aboutlibraries.ui.compose.util.strippedLicenseContent
 import io.github.droidkaigi.confsched.droidkaigiui.component.AnimatedTextTopAppBar
 import org.jetbrains.compose.resources.stringResource
 
@@ -38,6 +45,17 @@ fun LicensesScreen(
                 nameOverflow = TextOverflow.Visible,
                 nameMaxLines = 3,
             ),
+            licenseDialogBody = { library ->
+                Column(modifier = Modifier.padding(8.dp)) {
+                    Text(
+                        text = library.name,
+                        style = MaterialTheme.typography.headlineSmall,
+                    )
+                    Text(library.description ?: "")
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                    Text(library.strippedLicenseContent)
+                }
+            },
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(scrollBehavior.nestedScrollConnection),

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/LicensesScreen.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/LicensesScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextOverflow
 import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import io.github.droidkaigi.confsched.droidkaigiui.component.AnimatedTextTopAppBar
 import org.jetbrains.compose.resources.stringResource
@@ -32,6 +34,10 @@ fun LicensesScreen(
         LibrariesContainer(
             libraries = libraries,
             contentPadding = innerPadding,
+            textStyles = LibraryDefaults.libraryTextStyles(
+                nameOverflow = TextOverflow.Visible,
+                nameMaxLines = 3,
+            ),
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(scrollBehavior.nestedScrollConnection),


### PR DESCRIPTION
## Issue
- close #325 

## Overview (Required)
- keep library name from being omitted
- add padding for LicenseDialog
- show library name and description on LicenseDialog

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img width="300" alt="Screenshot_20250827_170552" src="https://github.com/user-attachments/assets/4422bbae-3b47-4826-8563-675933c8b2f1" /> | <img width="300" alt="Screenshot_20250827_170323" src="https://github.com/user-attachments/assets/2b21d86d-4663-4d88-8e2a-f4f9a2af8796" />
<img width="300" alt="Screenshot_20250827_170600" src="https://github.com/user-attachments/assets/fa348c58-3975-4312-abf3-405ea53a78ab" /> | <img width="300" alt="Screenshot_20250827_170348" src="https://github.com/user-attachments/assets/1e02312b-497e-4abf-86e5-8686503693b4" />
