### PR TITLE
Fix: SearchScreen not visible after clicking item on wide screens

### DIFF
--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SessionsNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SessionsNavEntry.kt
@@ -82,7 +82,7 @@ fun EntryProviderBuilder<NavKey>.searchEntry(
     onBackClick: () -> Unit = {},
     onTimetableItemClick: (TimetableItemId) -> Unit = {},
 ) {
-    entry<SearchNavKey> {
+    entry<SearchNavKey>(metadata = listDetailSceneStrategyListPaneMetaData()) {
         with(rememberSearchScreenContextRetained()) {
             SearchScreenRoot(
                 onBackClick = onBackClick,


### PR DESCRIPTION
## Issue
- close #313 

## Overview (Required)
- Fixed issue where SearchScreen disappeared after clicking an item to view details.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/4fb84564-bac0-44b9-8cf8-ade21fd906bf" width="300" > | <video src="https://github.com/user-attachments/assets/02dc8bc2-1e52-49a2-a6fb-3e5b3386f6e5" width="300" >

