### PR TITLE
fix : cut off DropdownMenu when visible soft keyboard

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchFilterRow.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchFilterRow.kt
@@ -20,9 +20,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.sessions.SearchScreenEvent
@@ -32,6 +35,7 @@ import io.github.droidkaigi.confsched.sessions.filter_chip_category
 import io.github.droidkaigi.confsched.sessions.filter_chip_day
 import io.github.droidkaigi.confsched.sessions.filter_chip_session_type
 import io.github.droidkaigi.confsched.sessions.filter_chip_supported_language
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
 const val SearchFilterRowTestTag = "SearchFilterRowTestTag"
@@ -124,12 +128,20 @@ private fun <T> FilterDropdown(
     onItemSelected: (T) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
     var expanded by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
 
     Box(modifier = modifier) {
         FilterChip(
             selected = selectedItems.isNotEmpty(),
-            onClick = { expanded = true },
+            onClick = {
+                scope.launch {
+                    withFrameNanos {
+                        keyboardController?.hide()
+                    }
+                }.invokeOnCompletion { expanded = true }
+            },
             label = {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Issue
- close #292 

## Overview (Required)
- This PR is to address the issue where the filtering DropdownMenu on the search screen is cut off. #292 

Added hide function handling to explicitly lower the soft keyboard.
Use withFrameNanos to operate based on the frame used by the device.

## Links

Comparing [DroidKaigi/conference-app-2024](https://github.com/DroidKaigi/conference-app-2024) and [DroidKaigi/conference-app-2025](https://github.com/DroidKaigi/conference-app-2025), I confirmed that the Material version increased from 1.2.1 to 1.4.0.

While testing with the updated versions, we confirmed that the padding for the time delay in Dropdown has become stricter since version 1.3.1.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/846d703e-d62a-419c-a93f-e8713f2b29c2" width="300" > | <video src="https://github.com/user-attachments/assets/5ba259e1-588f-4093-8678-0078d70596b7" width="300" >






