### PR TITLE
:wrench: We have fixed the locations where the old openURL method was being used.

### DIFF
--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
@@ -34,11 +34,25 @@ actual fun rememberExternalNavController(): ExternalNavController {
 internal class IosExternalNavController : ExternalNavController {
     override fun navigate(url: String) {
         val nsUrl = NSURL.URLWithString(url)
-        if (nsUrl != null) {
-            UIApplication.sharedApplication.openURL(nsUrl)
-        } else {
-            println("Failed to navigate to URL: $url")
+        if (nsUrl == null) {
+            println("Failed to navigate to URL (invalid URL): $url")
+            return
         }
+
+        if (!UIApplication.sharedApplication.canOpenURL(nsUrl)) {
+            println("Cannot open URL (scheme not allowed or no handler): $url")
+            return
+        }
+
+        UIApplication.sharedApplication.openURL(
+            url = nsUrl,
+            options = emptyMap<Any?, Any?>(),
+            completionHandler = { success ->
+                if (!success) {
+                    println("Failed to open URL via UIApplication.open(_:options:completionHandler:): $url")
+                }
+            },
+        )
     }
 
     @OptIn(ExperimentalForeignApi::class)


### PR DESCRIPTION
## Issue
- close #418

## Overview (Required)
- The process for opening URLs has been fixed to function properly this fiscal year, just as it did last year.

## Links
- https://developer.apple.com/documentation/uikit/uiapplication/openurl(_:)
- https://developer.apple.com/documentation/uikit/uiapplication/open(_:options:completionhandler:)

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/4ed8e16f-2b0d-4086-85e6-a4f2f85159bd" width="300" > | <video src="https://github.com/user-attachments/assets/06984b56-980b-4956-9993-8881b0b99a9c" width="300" >