### PR TITLE
:wrench: 【ComposeMultiplatform】The app crashes when attempting to transition to the ProfileCardScreen.

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
@@ -233,7 +233,18 @@ private fun Form<Profile>.Image() {
         stringResource(ProfileRes.string.image),
     )
     var image: PlatformFile? by remember(value.imagePath) {
-        mutableStateOf(PlatformFile(value.imagePath).takeIf { it.exists() })
+        mutableStateOf(
+            value.imagePath
+                .takeIf { it.isNotBlank() }
+                ?.takeIf { path ->
+                    path.startsWith("file://") ||
+                        path.startsWith("content://") ||
+                        !path.contains("://")
+                }
+                ?.let { safePath ->
+                    runCatching { PlatformFile(safePath).takeIf { it.exists() } }.getOrNull()
+                }
+        )
     }
 
     Field(

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
@@ -243,7 +243,7 @@ private fun Form<Profile>.Image() {
                 }
                 ?.let { safePath ->
                     runCatching { PlatformFile(safePath).takeIf { it.exists() } }.getOrNull()
-                }
+                },
         )
     }
 


### PR DESCRIPTION
## Issue
- close #422

## Overview (Required)
- The reason for the crash on iOS is as follows:

- The initial display is imagePath == “”(empty string).
- The iOS FileKit implementation uses NSURL to handle paths internally when creating PlatformFile(path) or calling exists().
- However, empty strings or non-file URLs like http(s):// can result in NSURL.path == null.
- This causes it to throw a FileKitNSURLNullPathException(meaning “NSURL's path is null”).
- Since the exception isn't caught, it crashes immediately.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
