### PR TITLE
fix(SearchScreen): add imePadding

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched.sessions
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -33,7 +34,8 @@ fun SearchScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .imePadding(),
         ) {
             SearchFilterRow(
                 filters = uiState.availableFilters,


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/330

## Overview (Required)
- Added imePadding at SearchScreen to avoid hiding some contents

## Links
- N/A

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/3a321501-4f1a-4438-ae5c-f36fb51369cd" width="300" > | <img src="https://github.com/user-attachments/assets/bd5fb1e0-07fa-4c29-8a55-54382ea01a51" width="300" >



