### PR TITLE
:wrench: Fixed the background color of the loading sponsor.

### DIFF
--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -158,7 +159,10 @@ fun SponsorItem(
     modifier: Modifier = Modifier,
     onSponsorsItemClick: (url: String) -> Unit,
 ) {
-    val painter = rememberAsyncImagePainter(sponsor.logo)
+    val painter = rememberAsyncImagePainter(
+        model = sponsor.logo,
+        placeholder = ColorPainter(Color.White),
+    )
     Card(
         modifier = modifier.clickable { onSponsorsItemClick(sponsor.link) },
         colors = CardDefaults.cardColors(


### PR DESCRIPTION
Originally gray was displayed, so I changed it to match the card's background color.

## Issue
- close #440

## Overview (Required)
- Originally gray was displayed, so I changed it to match the card's background color.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/fe65ce10-a2d1-463e-b8de-913906fe5833" width="300" > | <video src="https://github.com/user-attachments/assets/48558c19-e4a1-4faa-a325-280274ebfd05" width="300" >