### PR TITLE
Liquid Glass effect

### DIFF
--- a/app-ios/Native/Sources/Root/RootScreen.swift
+++ b/app-ios/Native/Sources/Root/RootScreen.swift
@@ -215,7 +215,7 @@ public struct RootScreen: View {
             }
         }
     }
-    
+
     @ViewBuilder
     private func aboutDestinationView(for destination: AboutNavigationDestination) -> some View {
         switch destination {
@@ -231,7 +231,7 @@ public struct RootScreen: View {
             SettingsScreen()
         }
     }
-    
+
     private var profileCardTab: some View {
         NavigationStack(path: $profileCardNavigationPath) {
             ProfileCardScreen(onNavigate: handleProfileCardNavigation)
@@ -244,7 +244,7 @@ public struct RootScreen: View {
                 }
         }
     }
-    
+
     private func handleHomeNavigation(_ destination: HomeNavigationDestination) {
         switch destination {
         case .timetableDetail(let item):
@@ -253,15 +253,15 @@ public struct RootScreen: View {
             timetableNavigationPath.append(NavigationDestination.search)
         }
     }
-    
+
     private func handleAboutNavigation(_ destination: AboutNavigationDestination) {
         aboutNavigationPath.append(destination)
     }
-    
+
     private func handleFavoriteNavigation(_ destination: FavoriteNavigationDestination) {
         favoriteNavigationPath.append(destination)
     }
-    
+
     private func handleSearchNavigation(_ destination: SearchNavigationDestination) {
         switch destination {
         case .timetableDetail(let item):


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/146

## Overview (Required)
- For iOS26 and later, we've added a Liquid Glass effect to the tab bar. For versions earlier than iOS26, we've retained the existing Liquid Glass-style design.
Additionally, when transparency is disabled in settings, we've adjusted it to reduce transparency regardless of the iOS version.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/df3fe0f7-ab0a-407c-ad30-8fa98cd228a7" width="300" > | <video src="https://github.com/user-attachments/assets/87c5a7e2-82fd-4f4e-aa44-e7d2876309ea" width="300" >

