### PR TITLE
Enable horizontal scrolling for OutlinedTextField in ProfileEditScreen

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
@@ -403,6 +403,7 @@ private fun FormField<String>.InputField(
             onValueChange = { onValueChange(it) },
             isError = hasError,
             maxLines = 1,
+            singleLine = true,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             trailingIcon = {


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
Long text wraps and scrolls vertically, but for single-line inputs, horizontal scrolling feels more natural.

## Links
- https://developer.android.com/develop/ui/compose/text/user-input?textfield=state-based#line-limits
> The SingleLine configuration has the following characteristics:
> - The text never wraps, and doesn't allow for new lines.
> - TextField always has a fixed height.
> - If the text overflows, it scrolls horizontally.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/b0a84d07-f364-4f35-bf94-e86da8a6eaa3" width="300" > | <video src="https://github.com/user-attachments/assets/a84b1692-6b96-4a72-93f0-2c830dafd007" width="300" >


