### PR TITLE
Add `CoilRule` to `DroidKaigiKmpPreviewTester`

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -45,6 +45,8 @@ kotlin {
             implementation(libs.androidxDatastorePreferencesCore)
             implementation(libs.material3)
 
+            implementation(libs.coilTest)
+
             implementation(kotlin("test"))
         }
 

--- a/core/testing/src/androidMain/kotlin/io/github/droidkaigi/confsched/testing/previewtester/DroidKaigiKmpPreviewTester.kt
+++ b/core/testing/src/androidMain/kotlin/io/github/droidkaigi/confsched/testing/previewtester/DroidKaigiKmpPreviewTester.kt
@@ -9,6 +9,7 @@ import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziActivity
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.github.takahirom.roborazzi.registerRoborazziActivityToRobolectricIfNeeded
+import io.github.droidkaigi.confsched.testing.rule.CoilRule
 import org.junit.rules.RuleChain
 import org.junit.rules.TestWatcher
 import sergio.sastre.composable.preview.scanner.jvm.common.CommonComposablePreviewScanner
@@ -58,6 +59,7 @@ class DroidKaigiKmpPreviewTester : ComposePreviewTester<ComposePreviewTester.Tes
                         }
                     },
                 ).around(composeTestRule)
+                    .around(CoilRule())
             },
         ),
     )

--- a/core/testing/src/androidMain/kotlin/io/github/droidkaigi/confsched/testing/previewtester/DroidKaigiKmpPreviewTester.kt
+++ b/core/testing/src/androidMain/kotlin/io/github/droidkaigi/confsched/testing/previewtester/DroidKaigiKmpPreviewTester.kt
@@ -58,7 +58,8 @@ class DroidKaigiKmpPreviewTester : ComposePreviewTester<ComposePreviewTester.Tes
                             registerRoborazziActivityToRobolectricIfNeeded()
                         }
                     },
-                ).around(composeTestRule)
+                )
+                    .around(composeTestRule)
                     .around(CoilRule())
             },
         ),

--- a/core/testing/src/androidMain/kotlin/io/github/droidkaigi/confsched/testing/rule/CoilRule.kt
+++ b/core/testing/src/androidMain/kotlin/io/github/droidkaigi/confsched/testing/rule/CoilRule.kt
@@ -1,0 +1,26 @@
+package io.github.droidkaigi.confsched.testing.rule
+
+import android.graphics.Color
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.annotation.DelicateCoilApi
+import coil3.test.FakeImageLoaderEngine
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(DelicateCoilApi::class)
+class CoilRule : TestWatcher() {
+    override fun starting(description: Description?) {
+        super.starting(description)
+        val engine = FakeImageLoaderEngine.Builder()
+            .default(ColorImage(Color.BLUE))
+            .build()
+        val imageLoader =
+            ImageLoader.Builder(ApplicationProvider.getApplicationContext())
+                .components { add(engine) }
+                .build()
+        SingletonImageLoader.setUnsafe(imageLoader)
+    }
+}


### PR DESCRIPTION
## Issue
- close #439

## Overview (Required)
- add `CoilRule` which uses a fake engine that returns a blue image
- add `CoilRule` to `DroidKaigiKmpPreviewTester`

## Links
- https://coil-kt.github.io/coil/testing/

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/0c24f41a-409f-4676-bd5f-81b4c7bd8208" width="300" /> | <img src="https://github.com/user-attachments/assets/7abfca21-0b7d-45c6-8fce-accd5f03fc37" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
