### PR TITLE
【ComposeMultiplatform】Implement the transition to the StaffScreen.

### DIFF
--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.ios.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.ios.kt
@@ -23,6 +23,7 @@ import io.github.droidkaigi.confsched.navigation.extension.navigateToProfileCard
 import io.github.droidkaigi.confsched.navigation.extension.navigateToSearch
 import io.github.droidkaigi.confsched.navigation.extension.navigateToSettings
 import io.github.droidkaigi.confsched.navigation.extension.navigateToSponsors
+import io.github.droidkaigi.confsched.navigation.extension.navigateToStaffs
 import io.github.droidkaigi.confsched.navigation.extension.navigateToTimetableItemDetail
 import io.github.droidkaigi.confsched.navigation.extension.navigateToTimetableTab
 import io.github.droidkaigi.confsched.navigation.graph.aboutTabNavGraph
@@ -103,7 +104,7 @@ actual fun KaigiAppUi() {
                     when (it) {
                         AboutItem.Map -> TODO()
                         AboutItem.Contributors -> TODO()
-                        AboutItem.Staff -> TODO()
+                        AboutItem.Staff -> navController.navigateToStaffs()
                         AboutItem.Sponsors -> navController.navigateToSponsors()
                         AboutItem.CodeOfConduct -> TODO()
                         AboutItem.License -> navController.navigateToLicenses()

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/AboutNavExtension.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/AboutNavExtension.kt
@@ -5,6 +5,7 @@ import io.github.droidkaigi.confsched.navigation.route.AboutTabRoute
 import io.github.droidkaigi.confsched.navigation.route.LicensesRoute
 import io.github.droidkaigi.confsched.navigation.route.SettingsRoute
 import io.github.droidkaigi.confsched.navigation.route.SponsorsRoute
+import io.github.droidkaigi.confsched.navigation.route.StaffsRoute
 
 fun NavController.navigateToAboutTab() {
     navigate(AboutTabRoute) {
@@ -23,4 +24,8 @@ fun NavController.navigateToLicenses() {
 
 fun NavController.navigateToSettings() {
     navigate(SettingsRoute)
+}
+
+fun NavController.navigateToStaffs() {
+    navigate(StaffsRoute)
 }

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/graph/AboutNavGraph.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/graph/AboutNavGraph.kt
@@ -14,10 +14,13 @@ import io.github.droidkaigi.confsched.navigation.route.AboutTabRoute
 import io.github.droidkaigi.confsched.navigation.route.LicensesRoute
 import io.github.droidkaigi.confsched.navigation.route.SettingsRoute
 import io.github.droidkaigi.confsched.navigation.route.SponsorsRoute
+import io.github.droidkaigi.confsched.navigation.route.StaffsRoute
 import io.github.droidkaigi.confsched.settings.SettingsScreenRoot
 import io.github.droidkaigi.confsched.settings.rememberSettingsScreenContextRetained
 import io.github.droidkaigi.confsched.sponsors.SponsorScreenRoot
 import io.github.droidkaigi.confsched.sponsors.rememberSponsorsScreenContextRetained
+import io.github.droidkaigi.confsched.staff.StaffScreenRoot
+import io.github.droidkaigi.confsched.staff.rememberStaffScreenContextRetained
 
 context(appGraph: AppGraph)
 fun NavGraphBuilder.aboutTabNavGraph(
@@ -32,6 +35,7 @@ fun NavGraphBuilder.aboutTabNavGraph(
         sponsorsNavGraph(onBackClick = onBackClick, onLinkClick = onLinkClick)
         licensesNavGraph(onBackClick = onBackClick)
         settingsNavGraph(onBackClick = onBackClick)
+        staffsNavGraph(onBackClick = onBackClick, onLinkClick = onLinkClick)
     }
 }
 
@@ -83,6 +87,21 @@ fun NavGraphBuilder.settingsNavGraph(
     composable<SettingsRoute> {
         with(rememberSettingsScreenContextRetained()) {
             SettingsScreenRoot(
+                onBackClick = onBackClick,
+            )
+        }
+    }
+}
+
+context(appGraph: AppGraph)
+fun NavGraphBuilder.staffsNavGraph(
+    onBackClick: () -> Unit,
+    onLinkClick: (String) -> Unit,
+) {
+    composable<StaffsRoute> {
+        with(rememberStaffScreenContextRetained()) {
+            StaffScreenRoot(
+                onStaffItemClick = onLinkClick,
                 onBackClick = onBackClick,
             )
         }

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/route/AboutTabRoute.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/route/AboutTabRoute.kt
@@ -19,3 +19,6 @@ data object LicensesRoute
 
 @Serializable
 data object SettingsRoute
+
+@Serializable
+data object StaffsRoute

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/about/AboutItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/about/AboutItem.kt
@@ -1,5 +1,8 @@
 package io.github.droidkaigi.confsched.model.about
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 enum class AboutItem {
     Map,
 


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2025/issues/416

## Overview (Required)
- Navigation implementation when navigating from About Screen to Staff Screen on CMP.

## Movie

Before | After
:--: | :--:
Staff screen is not displayed | ![Kapture 2025-08-30 at 12 57 33](https://github.com/user-attachments/assets/63d7f2a4-37a6-45ad-b5c3-c17465580ce0)


