### PR TITLE
Refactor: change id default from nil to `UUID().uuidString`

### DIFF
--- a/app-ios/Core/Sources/Model/TimetableTimeGroupItems.swift
+++ b/app-ios/Core/Sources/Model/TimetableTimeGroupItems.swift
@@ -6,9 +6,13 @@ public struct TimetableTimeGroupItems: Identifiable, Equatable, Sendable {
     public let endsTimeString: String
     public var items: [TimetableItemWithFavorite]
 
-    public init(id: String? = nil, startsTimeString: String, endsTimeString: String, items: [TimetableItemWithFavorite])
-    {
-        self.id = id ?? UUID().uuidString
+    public init(
+        id: String = UUID().uuidString,
+        startsTimeString: String,
+        endsTimeString: String,
+        items: [TimetableItemWithFavorite]
+    ) {
+        self.id = id
         self.startsTimeString = startsTimeString
         self.endsTimeString = endsTimeString
         self.items = items


### PR DESCRIPTION

## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- When the `id` argument is omitted, the parameter defaults to `nil`, and the initializer immediately coalesces it (`id ?? UUID().uuidString`). This default-then-branch layering is redundant.
- Also, allowing call sites to pass `id: nil` (`TimetableTimeGroupItems(id: nil, ... )`) results in the same behavior as omitting the parameter. That’s not simple.

### Note:

- This is a source-breaking change for call sites that explicitly pass `id: nil`; omit the parameter instead.
However, because no current call sites pass `id: nil`, the change is low-risk for our codebase; proceeding now helps prevent the optional type from propagating further.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
