### PR TITLE
Refactor: centralize `staffTask` cancellation via property observer

### DIFF
--- a/app-ios/Native/Sources/Feature/Staff/StaffPresenter.swift
+++ b/app-ios/Native/Sources/Feature/Staff/StaffPresenter.swift
@@ -17,14 +17,17 @@ final class StaffPresenter {
     var staffList: [Model.Staff] = []
     var isLoading = false
 
-    private var staffTask: Task<Void, Never>?
+    private var staffTask: Task<Void, Never>? {
+        willSet {
+            staffTask?.cancel()
+        }
+    }
 
     init() {}
 
     func loadStaff() async {
         isLoading = true
 
-        staffTask?.cancel()
         staffTask = Task {
             for await staffList in staffProvider.loadStaff() {
                 guard !Task.isCancelled else { break }
@@ -44,7 +47,6 @@ final class StaffPresenter {
     }
 
     func cleanup() {
-        staffTask?.cancel()
         staffTask = nil
     }
 }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)

Centralize cancellation of `staffTask` in a property observer so that:

- reassigning `staffTask` always cancels the previous task, and
- setting staffTask = nil (e.g., in cleanup) cancels as well.

Of course, I think the code before the change is also good. Because it explicitly does `cancel()` even before setting `nil` to `Task`. It also does `cancel()` before setting a new `Task`. These are the evidence that he understands the specification of keeping `Task` well.

However, it is tedious to always write `cancel()`. Since it is sometimes forgotten, this PR's method to use `willSet` should be better.


## Links
- https://developer.apple.com/documentation/swift/task
  - >  if you discard the reference to a task, you give up the ability to wait for that task’s result or cancel the task.


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
