### PR TITLE
Add CI to upload a desktop artifact so the desktop app can be downloaded

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -37,5 +37,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: desktop-app-build-${{ matrix.os }}
-          path: app-desktop/build/compose/binaries/main/app
+          path: app-desktop/build/compose/binaries/main/**/*
           retention-days: 14


### PR DESCRIPTION
## Issue
- close #443

## Overview (Required)
- Added a step to CI to upload the build results of the desktop app
- To build a desktop app in an executable format, you need to build it with the createDistributable task for each OS

## Links
- https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-native-distribution.html

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
