### PR TITLE
【ComposeMultiplatform】Implemented the remaining web transitions for the aboutTabNavGraph

### DIFF
--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.ios.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.ios.kt
@@ -14,6 +14,8 @@ import dev.chrisbanes.haze.rememberHazeState
 import io.github.droidkaigi.confsched.component.KaigiNavigationScaffold
 import io.github.droidkaigi.confsched.component.MainScreenTab
 import io.github.droidkaigi.confsched.model.about.AboutItem
+import io.github.droidkaigi.confsched.model.core.Lang
+import io.github.droidkaigi.confsched.model.core.defaultLang
 import io.github.droidkaigi.confsched.navigation.component.NavHostWithSharedAxisX
 import io.github.droidkaigi.confsched.navigation.extension.navigateToAboutTab
 import io.github.droidkaigi.confsched.navigation.extension.navigateToEventMapTab
@@ -100,18 +102,45 @@ actual fun KaigiAppUi() {
             )
             aboutTabNavGraph(
                 onAboutItemClick = {
+                    val portalBaseUrl = if (defaultLang() == Lang.JAPANESE) {
+                        "https://portal.droidkaigi.jp"
+                    } else {
+                        "https://portal.droidkaigi.jp/en"
+                    }
                     when (it) {
-                        AboutItem.Map -> TODO()
+                        AboutItem.Map -> externalNavController.navigate(
+                            url = "https://goo.gl/maps/vv9sE19JvRjYKtSP9",
+                        )
                         AboutItem.Contributors -> TODO()
                         AboutItem.Staff -> TODO()
                         AboutItem.Sponsors -> navController.navigateToSponsors()
-                        AboutItem.CodeOfConduct -> TODO()
+                        AboutItem.CodeOfConduct -> {
+                            externalNavController.navigate(
+                                url = "$portalBaseUrl/about/code-of-conduct",
+                            )
+                        }
                         AboutItem.License -> navController.navigateToLicenses()
-                        AboutItem.PrivacyPolicy -> TODO()
+                        AboutItem.PrivacyPolicy -> {
+                            externalNavController.navigate(
+                                url = "$portalBaseUrl/about/privacy",
+                            )
+                        }
                         AboutItem.Settings -> navController.navigateToSettings()
-                        AboutItem.Youtube -> TODO()
-                        AboutItem.X -> TODO()
-                        AboutItem.Medium -> TODO()
+                        AboutItem.Youtube -> {
+                            externalNavController.navigate(
+                                url = "https://www.youtube.com/c/DroidKaigi",
+                            )
+                        }
+                        AboutItem.X -> {
+                            externalNavController.navigate(
+                                url = "https://x.com/DroidKaigi",
+                            )
+                        }
+                        AboutItem.Medium -> {
+                            externalNavController.navigate(
+                                url = "https://medium.com/droidkaigi",
+                            )
+                        }
                     }
                 },
                 onBackClick = navController::popBackStack,


### PR DESCRIPTION
## Issue
- close #414 
## Overview (Required)
- I implemented the web navigation section (where the ToDo items are located) in `KaigiAppUi.ios.kt` using the `navigate` function from `ExternalNavController.kt`.

## Movie (Optional)
<video src="https://github.com/user-attachments/assets/4a859d13-b541-4b09-a574-eb643e1534d0" width="300" > 
