### PR TITLE
feat: set dark color scheme for custom tabs

### DIFF
--- a/app-shared/src/androidMain/kotlin/io/github/droidkaigi/confsched/AndroidExternalNavController.kt
+++ b/app-shared/src/androidMain/kotlin/io/github/droidkaigi/confsched/AndroidExternalNavController.kt
@@ -178,6 +178,7 @@ class AndroidExternalNavController(
         return try {
             CustomTabsIntent.Builder()
                 .setShowTitle(true)
+                .setColorScheme(CustomTabsIntent.COLOR_SCHEME_DARK)
                 .build()
                 .launchUrl(context, uri)
             true


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- This app only has a dark theme, so I thought it would be more appropriate to specify the dark color scheme when opening it in CustomTabs.

## Links
- https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder#setColorScheme(int)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/1bb6379f-02d7-46e7-bfa1-bb04d00f7302" width="300" /> | <img src="https://github.com/user-attachments/assets/dcbfb441-1292-433e-9857-f20f56869aaa" width="300" />
