### PR TITLE
:wrench: We have made fixes to prevent the app from crashing when using the share feature on iPad.

### DIFF
--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
@@ -162,7 +162,7 @@ internal class IosExternalNavController : ExternalNavController {
      * - Instead, this method searches for a foreground-active [UIWindowScene],
      *   retrieves its key window, and then resolves the top-most visible view controller.
      *
-     * @see <a href="https://developer.apple.com/documentation/uikit/uiapplication/1622924-keywindow">
+     * @see <a href="https://developer.apple.com/documentation/uikit/uiapplication/keywindow">
      *      UIApplication.keyWindow (deprecated)</a>
      * @see <a href="https://developer.apple.com/documentation/uikit/uiwindowscene">
      *      UIWindowScene – Apple Developer Documentation</a>

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
@@ -117,9 +117,7 @@ internal class IosExternalNavController : ExternalNavController {
             activityItems = items,
             applicationActivities = null,
         )
-        MainScope().launch {
-            presentAsPopoverSafely(activityViewController)
-        }
+        presentAsPopoverSafely(activityViewController)
     }
 
     /**

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/IosExternalNavController.kt
@@ -11,9 +11,11 @@ import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.useContents
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.datetime.toNSDate
+import platform.CoreGraphics.CGRectMake
 import platform.EventKit.EKEntityType
 import platform.EventKit.EKEvent
 import platform.EventKit.EKEventStore
@@ -24,7 +26,16 @@ import platform.Foundation.NSURL
 import platform.Foundation.create
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
+import platform.UIKit.UIDevice
 import platform.UIKit.UIImage
+import platform.UIKit.UINavigationController
+import platform.UIKit.UISceneActivationStateForegroundActive
+import platform.UIKit.UITabBarController
+import platform.UIKit.UIUserInterfaceIdiomPad
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+import platform.UIKit.popoverPresentationController
 
 @Composable
 actual fun rememberExternalNavController(): ExternalNavController {
@@ -106,12 +117,113 @@ internal class IosExternalNavController : ExternalNavController {
             activityItems = items,
             applicationActivities = null,
         )
+        MainScope().launch {
+            presentAsPopoverSafely(activityViewController)
+        }
+    }
 
-        val rootViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
-        rootViewController?.presentViewController(
-            viewControllerToPresent = activityViewController,
-            animated = true,
-            completion = null,
-        )
+    /**
+     * Presents the given [UIActivityViewController] safely.
+     *
+     * - On iPad, `UIActivityViewController` is presented as a popover,
+     *   which requires an anchor (`sourceView`+`sourceRect` or `barButtonItem`)
+     *   to be set. Without it, a runtime exception will occur:
+     *   "UIPopoverPresentationController should have a non-nil sourceView or barButtonItem".
+     *
+     * This method sets the popover's source view and rect to the center of the presenter view.
+     * You can adjust [sourceRect] as needed to change the popover position.
+     *
+     * @see <a href="https://developer.apple.com/documentation/uikit/uiactivityviewcontroller">
+     *      UIActivityViewController – Apple Developer Documentation</a>
+     * @see <a href="https://developer.apple.com/documentation/uikit/uipopoverpresentationcontroller">
+     *      UIPopoverPresentationController – Apple Developer Documentation</a>
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    private fun presentAsPopoverSafely(activityVC: UIActivityViewController) {
+        val presenter = findPresentingViewController() ?: return
+
+        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+            activityVC.popoverPresentationController?.let { pop ->
+                pop.sourceView = presenter.view
+                presenter.view.bounds.useContents {
+                    // Currently, the center of the presenter.view screen is used as the anchor point, but this can be changed as needed.
+                    pop.sourceRect = CGRectMake(size.width / 2.0, size.height / 2.0, 0.0, 0.0)
+                }
+                pop.permittedArrowDirections = 0u
+            }
+        }
+
+        presenter.presentViewController(activityVC, true, null)
+    }
+
+    /**
+     * Finds the most appropriate [UIViewController] to present from.
+     *
+     * - Since iOS 13, apps can have multiple scenes (multi-window).
+     *   `UIApplication.keyWindow` is deprecated and may return `nil`.
+     * - Instead, this method searches for a foreground-active [UIWindowScene],
+     *   retrieves its key window, and then resolves the top-most visible view controller.
+     *
+     * @see <a href="https://developer.apple.com/documentation/uikit/uiapplication/1622924-keywindow">
+     *      UIApplication.keyWindow (deprecated)</a>
+     * @see <a href="https://developer.apple.com/documentation/uikit/uiwindowscene">
+     *      UIWindowScene – Apple Developer Documentation</a>
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    private fun findPresentingViewController(): UIViewController? {
+        val scenes = UIApplication.sharedApplication.connectedScenes
+            .filterIsInstance<UIWindowScene>()
+            .filter { it.activationState == UISceneActivationStateForegroundActive }
+
+        val window: UIWindow? = scenes.firstOrNull()
+            ?.windows
+            ?.filterIsInstance<UIWindow>()
+            ?.firstOrNull { it.keyWindow }
+            ?: UIApplication.sharedApplication.windows
+                .filterIsInstance<UIWindow>()
+                .firstOrNull { it.keyWindow }
+            ?: UIApplication.sharedApplication.windows
+                .filterIsInstance<UIWindow>()
+                .firstOrNull()
+
+        return topMostViewController(window?.rootViewController)
+    }
+
+    /**
+     * Traverses the presented view controller chain to find the top-most (visible) view controller.
+     *
+     * - UIKit maintains a single chain of presented view controllers (no cycles).
+     * - Using [generateSequence], we walk down the chain until the last presented VC.
+     *
+     * @see <a href="https://developer.apple.com/documentation/uikit/uiviewcontroller/1621380-presentedviewcontroller">
+     *      UIViewController.presentedViewController</a>
+     */
+    private fun topMostViewController(root: UIViewController?): UIViewController? {
+        val start = normalize(root) ?: return null
+        return generateSequence(start) { current ->
+            val presented = current.presentedViewController ?: return@generateSequence null
+            normalize(presented)
+        }.lastOrNull()
+    }
+
+    /**
+     * Normalizes special container controllers to return the actual visible child.
+     *
+     * - [UINavigationController] → returns its [visibleViewController] (top of the navigation stack).
+     * - [UITabBarController] → returns its [selectedViewController] (current tab).
+     * - Otherwise returns the given controller itself.
+     *
+     * This ensures we always deal with the screen the user actually sees,
+     * not the container itself.
+     *
+     * @see <a href="https://developer.apple.com/documentation/uikit/uinavigationcontroller">
+     *      UINavigationController – Apple Developer Documentation</a>
+     * @see <a href="https://developer.apple.com/documentation/uikit/uitabbarcontroller">
+     *      UITabBarController – Apple Developer Documentation</a>
+     */
+    private fun normalize(vc: UIViewController?): UIViewController? = when (vc) {
+        is UINavigationController -> vc.visibleViewController ?: vc
+        is UITabBarController -> vc.selectedViewController ?: vc
+        else -> vc
     }
 }


### PR DESCRIPTION
## Issue
- close #476

## Overview (Required)

## Problems in the Original Code (Before)

### 1. iPad popover anchor not set
- This was the **direct cause of the crash**.  
- On iPad, presenting a `UIActivityViewController` requires setting either `sourceView` or `barButtonItem` as an anchor.

### 2. Dependency on `UIApplication.sharedApplication.keyWindow?.rootViewController`
- Since iOS 13 with multi-scene support, `keyWindow` can be `nil` or may not point to the expected window.  
- The safe approach is to retrieve the foreground `keyWindow` via `UIWindowScene`.

### 3. Presenting without resolving the top-most ViewController
- In navigation/tab/stacked modal scenarios, the view controller used for presentation might not be the one actually visible.  
- The correct approach is to use `topMostViewController` to traverse and resolve the **currently visible top-most VC** before presenting.

## Links
- Deprecated https://developer.apple.com/documentation/uikit/uiapplication/keywindow

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/e98445a7-eb9e-4d85-995b-afdd44a60ea3" width="300" > | <video src="https://github.com/user-attachments/assets/f0a6e4b4-172d-4702-86d6-0f0863feb1c3" width="300" >