### PR TITLE
hide FlippableProfileCard while generating shareable card image

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileCardScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileCardScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
@@ -90,7 +91,10 @@ fun ProfileCardScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            FlippableProfileCard(uiState = uiState)
+            FlippableProfileCard(
+                uiState = uiState,
+                modifier = Modifier.alpha(if (shareableProfileCardRenderResult != null) 1f else 0f),
+            )
             Spacer(Modifier.height(32.dp))
             Button(
                 enabled = shareableProfileCardRenderResult != null,


### PR DESCRIPTION
## Issue
- close #441

## Overview (Required)
- Dynamically adjust `FlippableProfileCard` opacity based on `shareableProfileCardRenderResult`
  - 0f when null (before shareable card image generation)
  - 1f when not null (after shareable card image generation)

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/94eb4a8f-e62a-41e6-88d2-8fe20903acf3" width="300" > | <video src="https://github.com/user-attachments/assets/75db9343-9076-49cd-ab92-a5f6360eb713" width="300" >

