### PR TITLE
Optimize dependency repository settings

### DIFF
--- a/gradle-conventions/settings.gradle.kts
+++ b/gradle-conventions/settings.gradle.kts
@@ -2,16 +2,28 @@ rootProject.name = "gradle-conventions"
 
 pluginManagement {
     repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
         gradlePluginPortal()
         mavenCentral()
-        google()
     }
 }
 
 dependencyResolutionManagement {
     repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
         mavenCentral()
-        google()
         gradlePluginPortal()
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,17 +5,16 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     includeBuild("gradle-conventions")
     repositories {
+        google()
         gradlePluginPortal()
         mavenCentral()
-        google()
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        mavenCentral()
         google()
-        gradlePluginPortal()
+        mavenCentral()
         // navigation3 adaptive
         maven {
             url = uri("https://androidx.dev/snapshots/builds/13508953/artifacts/repository")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,13 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     includeBuild("gradle-conventions")
     repositories {
-        google()
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
         gradlePluginPortal()
         mavenCentral()
     }
@@ -13,7 +19,13 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
-        google()
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
         mavenCentral()
         // navigation3 adaptive
         maven {


### PR DESCRIPTION
## Issue
- 

## Overview (Required)
This PR optimizes dependency resolution configuration with three improvements:
  - Move `google()` to first position in both `pluginManagement` and `dependencyResolutionManagement`
  - Add `includeGroupByRegex` filters to restrict Google Maven repository
  - Remove `gradlePluginPortal()` from `dependencyResolutionManagement`

These changes reduce unnecessary fetch requests to other repositories by prioritizing filtered Google repository searches. This also mitigates supply chain attacks where malicious libraries mimicking Google libraries could be published on Maven Central.

With these changes, "Resource missing" requests reduced from 906 to 350. 

```bash
# Generate dependency resolution logs
./gradlew -m -i --refresh-dependencies assembleDevDebug 2>&1 | tee dependencies-before.log  # main branch
./gradlew -m -i --refresh-dependencies assembleDevDebug 2>&1 | tee dependencies-after.log # this branch

# Count "Resource missing" requests
grep "Resource missing" dependencies-before.log | wc -l  # 906
grep "Resource missing" dependencies-after.log | wc -l   # 350
```

Some unnecessary requests still remain when packages don't exist in `gradlePluginPortal()` but do exist in `mavenCentral()`. These are not addressed in this PR as strict management would compromise usability.

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/1045
- https://github.com/android/nowinandroid/blob/8092c60c0f7c043a9ae7d291fed5c29f69d6ad2d/settings.gradle.kts#L17-L44

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
