### PR TITLE
[JVM] Implement the JVM's getDefaultLocale

### DIFF
--- a/core/model/src/jvmMain/kotlin/io/github/droidkaigi/confsched/model/core/Locale.jvm.kt
+++ b/core/model/src/jvmMain/kotlin/io/github/droidkaigi/confsched/model/core/Locale.jvm.kt
@@ -1,6 +1,9 @@
 package io.github.droidkaigi.confsched.model.core
 
 actual fun getDefaultLocale(): Locale {
-    // FIXME: This is a temporary implementation.
-    return Locale.JAPAN
+    return if (java.util.Locale.getDefault() == java.util.Locale.JAPAN) {
+        Locale.JAPAN
+    } else {
+        Locale.OTHER
+    }
 }


### PR DESCRIPTION
## Issue
- close #456 

## Overview (Required)
- I implemented default locale for JVM environment.


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Windows | Mac
:--: | :--:
<img src="https://github.com/user-attachments/assets/298554f2-3a17-4eb5-8855-7bfdbb2f39b5" width="300" /> | <img src="https://github.com/user-attachments/assets/12961ac5-0773-492a-b128-273f2602760a" width="300" />
