### PR TITLE
Apply scrim for 3-button navigation

### DIFF
--- a/app-android/src/main/kotlin/io/github/droidkaigi/confsched/MainActivity.kt
+++ b/app-android/src/main/kotlin/io/github/droidkaigi/confsched/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched
 
 import android.graphics.Color.TRANSPARENT
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -13,6 +14,9 @@ class MainActivity : ComponentActivity() {
             statusBarStyle = SystemBarStyle.dark(scrim = TRANSPARENT),
             navigationBarStyle = SystemBarStyle.dark(scrim = TRANSPARENT),
         )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = true
+        }
         super.onCreate(savedInstanceState)
 
         with(appGraph) {


### PR DESCRIPTION
## Issue
- close #331

## Overview (Required)
- Applied a translucent scrim for the 3-button navigation
  - ref: https://developer.android.com/design/ui/mobile/guides/foundations/system-bars#button_modes
  - > Use a translucent three-button navigation for scrolling content. 
- The reason it was transparent even though it was translucent by default was because I was setting a transparent navigationBarStyle with `enableEdgeToEdge`.
  - https://github.com/DroidKaigi/conference-app-2025/blob/63a29d2201c46f822ee787dda456edf0a1cb8085/app-android/src/main/kotlin/io/github/droidkaigi/confsched/MainActivity.kt#L14
  - However, the default setting for the light theme is a white translucent scrim, which doesn't match the black-based design of this app.
  - #250
- I could set the navigationBarStyle of enableEdgeToEdge to semi-transparent black, but that would apply the scrim even with gesture navigation.
  - ref: https://developer.android.com/design/ui/mobile/guides/foundations/system-bars#gesture_navigation_mode
  - > Transparent gesture navigation bars are always recommended.
- For these reasons, I decided to enable `isNavigationBarContrastEnforced`.
## Links
- [Edge-to-edge design  |  Mobile  |  Android Developers](https://developer.android.com/design/ui/mobile/guides/layout-and-content/edge-to-edge)
- [Android system bars  |  Mobile  |  Android Developers](https://developer.android.com/design/ui/mobile/guides/foundations/system-bars)
## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/1ee86fdb-6ac1-4de9-b5d1-a0cc7fb3b426" width="300" /> | <img src="https://github.com/user-attachments/assets/7a6055a3-cb0d-4ddf-abf8-33242a90e121" width="300" />
<img src="https://github.com/user-attachments/assets/35722d4f-7e7a-48d4-b474-6b68375b21a0" width="300" /> | <img src="https://github.com/user-attachments/assets/b5077dbc-9a97-4232-ab05-98a0a08f1fc4" width="300" />

