### PR TITLE
Fixed the SearchScreen Layout

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -9,10 +9,20 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableList
+import io.github.droidkaigi.confsched.model.core.DroidKaigi2025Day
+import io.github.droidkaigi.confsched.model.sessions.TimetableItem
 import io.github.droidkaigi.confsched.model.sessions.TimetableItemId
+import io.github.droidkaigi.confsched.model.sessions.fake
+import io.github.droidkaigi.confsched.sessions.SearchScreenUiState.TimeSlot
 import io.github.droidkaigi.confsched.sessions.components.SearchFilterRow
 import io.github.droidkaigi.confsched.sessions.components.SearchNotFoundContent
 import io.github.droidkaigi.confsched.sessions.components.SearchTopBar
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.datetime.LocalTime
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.PreviewParameter
+import org.jetbrains.compose.ui.tooling.preview.PreviewParameterProvider
 
 @Composable
 fun SearchScreen(
@@ -68,5 +78,44 @@ fun SearchScreen(
                 }
             }
         }
+    }
+}
+
+private class SearchScreenPreviewParameterProvider : PreviewParameterProvider<PersistentMap<TimeSlot, List<TimetableItem>>> {
+    override val values: Sequence<PersistentMap<TimeSlot, List<TimetableItem>>> = sequenceOf(
+        persistentMapOf(
+            TimeSlot(
+                startTime = LocalTime.parse("11:20"),
+                endTime = LocalTime.parse("12:00"),
+            ) to listOf(
+                TimetableItem.Session.fake(),
+            ),
+        ),
+        persistentMapOf(),
+    )
+}
+
+@Preview
+@Composable
+private fun SearchScreenPreview(
+    @PreviewParameter(SearchScreenPreviewParameterProvider::class) groupedSessions: PersistentMap<TimeSlot, List<TimetableItem>>,
+) {
+    KaigiPreviewContainer {
+        SearchScreen(
+            uiState = SearchScreenUiState(
+                searchQuery = "DroidKaigi",
+                groupedSessions = groupedSessions,
+                availableFilters = SearchScreenUiState.Filters(
+                    availableDays = listOf(
+                        DroidKaigi2025Day.ConferenceDay1,
+                        DroidKaigi2025Day.ConferenceDay2,
+                    ),
+                ),
+                hasSearchCriteria = true,
+            ),
+            onBackClick = {},
+            onTimetableItemClick = {},
+            onEvent = {},
+        )
     }
 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -1,13 +1,19 @@
 package io.github.droidkaigi.confsched.sessions
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableList
 import io.github.droidkaigi.confsched.model.core.DroidKaigi2025Day
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
@@ -40,7 +46,7 @@ fun SearchScreen(
                 onBackClick = onBackClick,
             )
         },
-        contentWindowInsets = WindowInsets(),
+        contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal),
         modifier = modifier,
     ) { paddingValues ->
         Column(
@@ -73,6 +79,7 @@ fun SearchScreen(
                         isBookmarked = { timetableItemId ->
                             uiState.bookmarks.contains(timetableItemId)
                         },
+                        contentPadding = PaddingValues(16.dp),
                         highlightWord = uiState.searchQuery,
                     )
                 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchNotFoundContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchNotFoundContent.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,6 +32,7 @@ fun SearchNotFoundContent(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,


### PR DESCRIPTION
## Issue
(The issue had not been raised.)

In the SearchScreen, the SearchFilterRow and TimetableList overlaps with the Display Cutout.
Additionally, when switching to landscape mode, the content of SearchNotFoundContent is cut off.

## Overview (Required)
- We have fixed the SearchScreen and the SearchNotFoundContent.
    - SearchScreen
        - Preview created.
        - Adjusted the WindowInsets and Padding of the SearchScreen to prevent the SearchFilterRow and TimetableList from overlapping the Display Cutout.
        - Fixed the padding around the TimetableList in the SearchScreen.
    - SearchNotFoundContent
        - Modified to display content by scrolling vertically even when the screen is rotated horizontally.

## Links
none

## Screenshot (Optional if screenshot test is present or unrelated to UI)
### SearchScreen
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/cae3eadb-ddb6-49dc-86bb-a4a746e55aa7" width="300" /> | Top of the screen<br><img src="https://github.com/user-attachments/assets/b92322e9-4a18-42e2-bedd-b8904eb98528" width="300" />
<img src="https://github.com/user-attachments/assets/704c4b17-216e-40ed-a856-759f97c8df4f" width="300" /> | Bottom of the screen<br><img src="https://github.com/user-attachments/assets/e38674e4-361e-46e9-8ac8-48db1c115a99" width="300" />
<img src="https://github.com/user-attachments/assets/e708eea2-b337-4ab7-a070-e3fc69d45cef" width="300" /> | Top of the screen<br>Display Cutout is on the left side<br><img src="https://github.com/user-attachments/assets/faae2e40-a6be-4610-bb84-fcb73e21a8c1" width="300" />
<img src="https://github.com/user-attachments/assets/239faaec-8ffa-46e8-b336-8eaa641a6449" width="300" /> | Bottom of the screen<br>Display Cutout is on the left side<br><img src="https://github.com/user-attachments/assets/fd0e6155-1587-49f5-95f1-2ed9109e26a0" width="300" />
<img src="https://github.com/user-attachments/assets/bd981054-8487-4351-a209-045a400fd427" width="300" /> | Top of the screen<br>Display Cutout is on the right side<br><img src="https://github.com/user-attachments/assets/44c8d1f5-d0af-4906-a291-64ffe3bcc1c2" width="300" />
<img src="https://github.com/user-attachments/assets/b5e8f7a7-0508-4a85-8a6e-fd4ae37e424e" width="300" /> | Bottom of the screen<br>Display Cutout is on the right side<br><img src="https://github.com/user-attachments/assets/542e9ef0-d835-49cb-9cf1-efea04982fd5" width="300" />
# SearchNotFoundContent
Before | After
:--: | :--:
Vertical scrolling is not possible.<br><img src="https://github.com/user-attachments/assets/ad513da3-41cc-49c4-87a9-a6d7955b19da" width="300" /> | <img src="https://github.com/user-attachments/assets/f90c41a8-0fe1-4002-9e8b-8609c7cb063b" width="300" />
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/340c1cdd-2422-4f8d-88b9-f529b0a2ae30" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
