### PR TITLE
【ComposeMultiplatform】Implement the transition to the ContributorsScreen

### DIFF
--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.ios.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.ios.kt
@@ -16,6 +16,7 @@ import io.github.droidkaigi.confsched.component.MainScreenTab
 import io.github.droidkaigi.confsched.model.about.AboutItem
 import io.github.droidkaigi.confsched.navigation.component.NavHostWithSharedAxisX
 import io.github.droidkaigi.confsched.navigation.extension.navigateToAboutTab
+import io.github.droidkaigi.confsched.navigation.extension.navigateToContributors
 import io.github.droidkaigi.confsched.navigation.extension.navigateToEventMapTab
 import io.github.droidkaigi.confsched.navigation.extension.navigateToFavoritesTab
 import io.github.droidkaigi.confsched.navigation.extension.navigateToLicenses
@@ -103,7 +104,7 @@ actual fun KaigiAppUi() {
                 onAboutItemClick = {
                     when (it) {
                         AboutItem.Map -> TODO()
-                        AboutItem.Contributors -> TODO()
+                        AboutItem.Contributors -> navController.navigateToContributors()
                         AboutItem.Staff -> navController.navigateToStaffs()
                         AboutItem.Sponsors -> navController.navigateToSponsors()
                         AboutItem.CodeOfConduct -> TODO()

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/AboutNavExtension.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/extension/AboutNavExtension.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched.navigation.extension
 
 import androidx.navigation.NavController
 import io.github.droidkaigi.confsched.navigation.route.AboutTabRoute
+import io.github.droidkaigi.confsched.navigation.route.ContributorsRoute
 import io.github.droidkaigi.confsched.navigation.route.LicensesRoute
 import io.github.droidkaigi.confsched.navigation.route.SettingsRoute
 import io.github.droidkaigi.confsched.navigation.route.SponsorsRoute
@@ -28,4 +29,8 @@ fun NavController.navigateToSettings() {
 
 fun NavController.navigateToStaffs() {
     navigate(StaffsRoute)
+}
+
+fun NavController.navigateToContributors() {
+    navigate(ContributorsRoute)
 }

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/graph/AboutNavGraph.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/graph/AboutNavGraph.kt
@@ -8,9 +8,12 @@ import io.github.droidkaigi.confsched.about.AboutScreenRoot
 import io.github.droidkaigi.confsched.about.LicensesScreenRoot
 import io.github.droidkaigi.confsched.about.rememberAboutScreenContextRetained
 import io.github.droidkaigi.confsched.about.rememberLicensesScreenContextRetained
+import io.github.droidkaigi.confsched.contributors.ContributorsScreenRoot
+import io.github.droidkaigi.confsched.contributors.rememberContributorsScreenContextRetained
 import io.github.droidkaigi.confsched.model.about.AboutItem
 import io.github.droidkaigi.confsched.navigation.route.AboutRoute
 import io.github.droidkaigi.confsched.navigation.route.AboutTabRoute
+import io.github.droidkaigi.confsched.navigation.route.ContributorsRoute
 import io.github.droidkaigi.confsched.navigation.route.LicensesRoute
 import io.github.droidkaigi.confsched.navigation.route.SettingsRoute
 import io.github.droidkaigi.confsched.navigation.route.SponsorsRoute
@@ -36,6 +39,7 @@ fun NavGraphBuilder.aboutTabNavGraph(
         licensesNavGraph(onBackClick = onBackClick)
         settingsNavGraph(onBackClick = onBackClick)
         staffsNavGraph(onBackClick = onBackClick, onLinkClick = onLinkClick)
+        contributorsNavGraph(onBackClick = onBackClick, onLinkClick = onLinkClick)
     }
 }
 
@@ -103,6 +107,21 @@ fun NavGraphBuilder.staffsNavGraph(
             StaffScreenRoot(
                 onStaffItemClick = onLinkClick,
                 onBackClick = onBackClick,
+            )
+        }
+    }
+}
+
+context(appGraph: AppGraph)
+fun NavGraphBuilder.contributorsNavGraph(
+    onBackClick: () -> Unit,
+    onLinkClick: (String) -> Unit,
+) {
+    composable<ContributorsRoute> {
+        with(rememberContributorsScreenContextRetained()) {
+            ContributorsScreenRoot(
+                onBackClick = onBackClick,
+                onContributorClick = onLinkClick
             )
         }
     }

--- a/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/route/AboutTabRoute.kt
+++ b/app-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/navigation/route/AboutTabRoute.kt
@@ -22,3 +22,6 @@ data object SettingsRoute
 
 @Serializable
 data object StaffsRoute
+
+@Serializable
+data object ContributorsRoute


### PR DESCRIPTION
## Issue
- close #415 

## Overview (Required)
- Navigation implementation when navigating from About Screen to ContributorsScreen on CMP.

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" /> | <video src="https://github.com/user-attachments/assets/96d125a8-9aa7-43a7-a8be-452a58ed8d20" width="300" />

