### PR TITLE
Fix change the TimetableSpeaker design propeties

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableGridItem.kt
@@ -187,14 +187,14 @@ private fun TimetableSpeaker(
         )
         Text(
             text = speaker.name,
-            style = MaterialTheme.typography.titleSmall,
+            style = MaterialTheme.typography.labelMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             autoSize = TextAutoSize.StepBased(
                 minFontSize = TimetableGridItemDefaults.minTitleFontSize,
                 maxFontSize = TimetableGridItemDefaults.maxTitleFontSize,
             ),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
                 .align(Alignment.CenterVertically)
                 .padding(start = 8.dp),


### PR DESCRIPTION
## Issue
- close #495

## Overview
- Changed TimetableSpeaker design properties to match Figma design

	- style = MaterialTheme.typography.titleSmall -> style = MaterialTheme.typography.labelMedium

	- color = MaterialTheme.colorScheme.onSurfaceVariant -> color = MaterialTheme.colorScheme.onSurface

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/577462e2-887d-484b-ad05-ad44e40845b0" width="300" /> | <img src="https://github.com/user-attachments/assets/1a7ce385-975c-4e7c-925e-dfcb25b9a678" width="300" />

