### PR TITLE
Remove software keyboard consideration on the bottom navigation not to cover input fields

### DIFF
--- a/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/component/KaigiNavigationScaffold.kt
+++ b/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/component/KaigiNavigationScaffold.kt
@@ -8,7 +8,9 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -122,9 +124,9 @@ private fun KaigiNavigationScaffold(
                                 bottom = 32.dp,
                             )
                             .windowInsetsPadding(
-                                WindowInsets.safeDrawing.only(
-                                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
-                                ),
+                                WindowInsets.safeDrawing
+                                    .exclude(WindowInsets.ime)
+                                    .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
                             ),
                     )
                 }


### PR DESCRIPTION
## Issue
- close #384

## Overview (Required)
- Currently, the Bottom Navigation dodges the software keyboard to prevent overlapping. However, during composition, it could be disturbing by covering the input fields.
- We may want to leave overlapping so that the Bottom Navigation keeps under the keyboard. This PR proposes to remove IME inset consideration on the Navigation.

## Links
- N/A

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/e4c0796f-7622-4746-8f69-c45c43307ebb" width="300" /> | <img src="https://github.com/user-attachments/assets/c17e4eb2-26fa-4c15-82cb-26b8dd14d5e7" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/615193a5-4e22-4f15-9e9a-6db0ecca0c90" width="300" > | <video src="https://github.com/user-attachments/assets/51dbdc08-4dcd-4046-b4ad-160adfca6800" width="300" >
