### PR TITLE
replace twitter.com to x.com

### DIFF
--- a/app-ios/Native/Sources/Feature/About/AboutScreen.swift
+++ b/app-ios/Native/Sources/Feature/About/AboutScreen.swift
@@ -186,7 +186,7 @@ public struct AboutScreen: View {
                 imageName: "ic_xcom_logo"
             ) {
                 Task {
-                    await safari(URL(string: "https://twitter.com/DroidKaigi")!)
+                    await safari(URL(string: "https://x.com/DroidKaigi")!)
                 }
             }
 

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -152,7 +152,7 @@ actual fun KaigiAppUi() {
 
                             AboutItem.X -> {
                                 externalNavController.navigate(
-                                    url = "https://twitter.com/DroidKaigi",
+                                    url = "https://x.com/DroidKaigi",
                                 )
                             }
 


### PR DESCRIPTION
## Issue
- close #474 

## Overview (Required)
- "twitter.com" was changed to "x.com", so we should change the link of x account of DroidKaigi

## Links
- N/A

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
