### PR TITLE
[CI] Introduce label management workflow to clarify PR status

### DIFF
--- a/.github/workflows/remove-waiting-label.yml
+++ b/.github/workflows/remove-waiting-label.yml
@@ -1,0 +1,34 @@
+name: remove-waiting-label
+
+on:
+  workflow_run:
+    workflows: ["save-pr-number-for-removing-waiting-label"]
+    types:
+      - completed
+
+permissions:
+  actions: read    # for downloading artifacts
+  contents: read   # for accessing repository contents
+  pull-requests: write # for removing labels from pull requests
+
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download PR number
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+        with:
+          name: pr_number
+          path: ./
+          run_id: ${{ github.event.workflow_run.id }}
+      - name: Read PR number
+        id: pr_number
+        run: echo "::set-output name=number::$(cat pr_number.txt)"
+      - name: Remove label
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.pr_number.outputs.number }}
+          labels: |
+            Waiting for response or commit

--- a/.github/workflows/remove-waiting-label.yml
+++ b/.github/workflows/remove-waiting-label.yml
@@ -24,7 +24,7 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
       - name: Read PR number
         id: pr_number
-        run: echo "::set-output name=number::$(cat pr_number.txt)"
+        run: echo "number=$(cat pr_number.txt)" >> $GITHUB_OUTPUT
       - name: Remove label
         uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:

--- a/.github/workflows/save-pr-number-for-removing-waiting-label.yml
+++ b/.github/workflows/save-pr-number-for-removing-waiting-label.yml
@@ -1,0 +1,22 @@
+name: save-pr-number-for-removing-waiting-label
+
+on:
+  pull_request:
+    types: [ synchronize ]
+  issue_comment:
+    types: [ created ]
+  pull_request_review_comment:
+    types: [ created ]
+
+jobs:
+  save_pr_number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        run: |
+          echo ${{ github.event.pull_request.number || github.event.issue.number }} > pr_number.txt
+      - name: Upload PR number
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr_number
+          path: pr_number.txt


### PR DESCRIPTION
## Issue
N/A

## Overview (Required)
- As we did last year, introduce a label management workflow to reduce review effort.
- Nearly identical to last year’s workflow, with only minor updates to dependent actions.

How it works:
1. Manually label any PR or issue with `Waiting for response or commit`.
2. The label is automatically removed when the PR or issue is updated.


## Links
- https://github.com/DroidKaigi/conference-app-2024/blob/main/.github/workflows/save-pr-number-for-removing-waiting-label.yml
- https://github.com/DroidKaigi/conference-app-2024/blob/main/.github/workflows/remove-waiting-label.yml
