### PR TITLE
Improve load card front background res

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardFront.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardFront.kt
@@ -95,8 +95,13 @@ fun CardFrontBackgroundImage(
     isDark: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    /**
+     * Displaying high-resolution WebP images directly with painterResource results in poor performance, so we use Coil.
+     *
+     * Care must be taken when renaming resources, as Coil does not support Compose Multiplatform Resources and specifies files as strings.
+     * ref: https://github.com/coil-kt/coil/issues/2812
+     */
     AsyncImage(
-        // ref: https://github.com/coil-kt/coil/issues/2812
         model = if (isDark) {
             ProfileRes.getUri("drawable/card_front_background_night.webp")
         } else {

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardFront.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardFront.kt
@@ -17,12 +17,11 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import io.github.confsched.profile.innerShadow
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.model.profile.ProfileCardTheme
 import io.github.droidkaigi.confsched.profile.ProfileRes
-import io.github.droidkaigi.confsched.profile.card_front_background_day
-import io.github.droidkaigi.confsched.profile.card_front_background_night
 import io.github.droidkaigi.confsched.profile.card_front_bottom_curve
 import io.github.droidkaigi.confsched.profile.card_front_logo_frame_day
 import io.github.droidkaigi.confsched.profile.card_front_logo_frame_night
@@ -51,16 +50,8 @@ fun ProfileCardFront(
             ),
         contentAlignment = Alignment.Center,
     ) {
-        Image(
-            painter = painterResource(
-                if (theme.isDark) {
-                    ProfileRes.drawable.card_front_background_night
-                } else {
-                    ProfileRes.drawable.card_front_background_day
-                },
-            ),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
+        CardFrontBackgroundImage(
+            isDark = theme.isDark,
             modifier = Modifier.matchParentSize(),
         )
         ProfileCardUser(
@@ -97,6 +88,24 @@ fun ProfileCardFront(
             modifier = Modifier.matchParentSize(),
         )
     }
+}
+
+@Composable
+fun CardFrontBackgroundImage(
+    isDark: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    AsyncImage(
+        // ref: https://github.com/coil-kt/coil/issues/2812
+        model = if (isDark) {
+            ProfileRes.getUri("drawable/card_front_background_night.webp")
+        } else {
+            ProfileRes.getUri("drawable/card_front_background_day.webp")
+        },
+        contentScale = ContentScale.Crop,
+        contentDescription = null,
+        modifier = modifier,
+    )
 }
 
 @Preview

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ThemeWithShape.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ThemeWithShape.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,13 +24,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.model.profile.ProfileCardTheme
 import io.github.droidkaigi.confsched.profile.ProfileRes
-import io.github.droidkaigi.confsched.profile.card_front_background_day
-import io.github.droidkaigi.confsched.profile.card_front_background_night
 import io.github.droidkaigi.confsched.profile.card_theme_selector_check
 import io.github.droidkaigi.confsched.profile.card_theme_selector_logo_day
 import io.github.droidkaigi.confsched.profile.card_theme_selector_logo_night
@@ -61,16 +57,8 @@ fun ThemeWithShape(
             .clickable(onClick = onSelect),
         contentAlignment = Alignment.Center,
     ) {
-        Image(
-            painter = painterResource(
-                if (theme.isDark) {
-                    ProfileRes.drawable.card_front_background_night
-                } else {
-                    ProfileRes.drawable.card_front_background_day
-                },
-            ),
-            contentScale = ContentScale.Crop,
-            contentDescription = null,
+        CardFrontBackgroundImage(
+            isDark = theme.isDark,
             modifier = Modifier
                 .matchParentSize()
                 .clip(RoundedCornerShape(2.dp)),


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- The number of pixels in images `card_front_background_night.webp` and `card_front_background_day.webp` is large, so the performance is poor because they are directly loaded and expanded. I want to pass them through Coil.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
