### PR TITLE
Disable ripple effect for FlippableProfileCard

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -83,7 +84,11 @@ private fun ProfileCard(
 ) {
     Card(
         modifier = modifier
-            .clickable(enabled = interactionsEnabled) {
+            .clickable(
+                enabled = interactionsEnabled,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) {
                 onFlippedChange(!isFlipped)
             }
             .draggable(


### PR DESCRIPTION
## Issue
- close #475

## Overview (Required)
- Disabled ripple effect for FlippableProfileCard by adding `indication = null` to clickable modifier.

## Links
- None

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/c6a98e88-db3b-436a-bf9a-cd7eedc18a21" width="300" > | <video src="https://github.com/user-attachments/assets/4d0f49ab-e8b5-43c7-a43b-dc1e2110f0d4" width="300" >