### PR TITLE
[iOS] [ProfileCard] Support shape-based cropping for profile image

### DIFF
--- a/app-ios/App/DroidKaigi2025App.swift
+++ b/app-ios/App/DroidKaigi2025App.swift
@@ -9,6 +9,7 @@ import BackgroundTasks
 import Root
 import SwiftUI
 import Theme
+import ProfileCardFeature
 
 @main
 struct DroidKaigi2025App: App {
@@ -41,6 +42,7 @@ struct DroidKaigi2025App: App {
         bar.standardAppearance = appearance
         bar.compactAppearance = appearance
         bar.scrollEdgeAppearance = appearance
+        KMPProfileCardInitializer.initialize()
     }
 
     private func registerBackgroundTasks() {

--- a/app-ios/Native/Sources/Feature/ProfileCard/Components/ComposeProfileCardBridge.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/Components/ComposeProfileCardBridge.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import UIKit
+// import shared // KMPの共有モジュール
+
+// Compose UIをSwiftUIに埋め込むためのラッパービュー
+struct ComposeView<Content>: UIViewControllerRepresentable {
+    let content: () -> Content
+    
+    func makeUIViewController(context: Context) -> UIViewController {
+        // KMPのCompose UIをホストするViewController
+        let viewController = ComposeHostingController(content: content)
+        
+        // 背景を透明に設定
+        viewController.view.backgroundColor = UIColor.clear
+        
+        return viewController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        // 必要に応じて更新処理を実装
+    }
+}
+
+// KMPのProfileCardUserをラップするビュー
+struct ProfileCardUserView {
+    let isDarkTheme: Bool
+    let profileImageData: Data
+    let userName: String
+    let occupation: String
+    let profileCardTheme: Any
+    
+    // KMPのCompose UIコンポーネントを呼び出す
+    @MainActor func createComposeView() -> Any {
+        // KMPのProfileCardUserコンポーネントを作成
+        // ここではKMPとのインターフェースを定義
+        // 実際の実装はKMP側のiOSMainソースセットで行う
+        return KMPProfileCardUserFactory.shared.createProfileCardUser(
+            isDarkTheme: isDarkTheme,
+            profileImageData: profileImageData,
+            userName: userName,
+            occupation: occupation,
+            profileCardTheme: profileCardTheme
+        )
+    }
+}
+
+// KMPとのブリッジ用のViewController
+class ComposeHostingController<Content>: UIViewController {
+    let content: () -> Content
+    
+    init(content: @escaping () -> Content) {
+        self.content = content
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // 背景を透明に設定
+        view.backgroundColor = UIColor.clear
+        
+        // KMPのCompose UIをホスト
+        Task { @MainActor in
+            if let composeView = content() as? ProfileCardUserView {
+                let kmpView = await composeView.createComposeView()
+                // KMPのViewをUIViewControllerに追加
+                embedKMPView(kmpView)
+            }
+        }
+    }
+    
+    private func embedKMPView(_ kmpView: Any) {
+        // KMPのCompose UIをUIViewに変換して追加
+        // この実装はKMP側のプラットフォーム固有コードで行う
+        KMPViewEmbedder.shared.embedInViewController(
+            viewController: self,
+            kmpView: kmpView
+        )
+    }
+}
+
+// KMPとのインターフェース定義（実装はKMP側）
+@objc protocol KMPProfileCardUserFactoryProtocol: AnyObject {
+    @MainActor func createProfileCardUser(
+        isDarkTheme: Bool,
+        profileImageData: Data,
+        userName: String,
+        occupation: String,
+        profileCardTheme: Any
+    ) -> Any
+}
+
+@objc protocol KMPViewEmbedderProtocol: AnyObject {
+    @MainActor func embedInViewController(viewController: UIViewController, kmpView: Any)
+}
+
+// シングルトンインスタンス（KMP側で実装を注入）createKMPProfileCardViewController
+@MainActor
+class KMPProfileCardUserFactory {
+    static let shared = KMPProfileCardUserFactory()
+    var implementation: KMPProfileCardUserFactoryProtocol?
+    
+    func createProfileCardUser(
+        isDarkTheme: Bool,
+        profileImageData: Data,
+        userName: String,
+        occupation: String,
+        profileCardTheme: Any
+    ) -> Any {
+        guard let impl = implementation else {
+            // 実装が設定されていない場合は、ダミーのViewを返す
+            print("Warning: KMPProfileCardUserFactory implementation not set")
+            return UIView()
+        }
+        return impl.createProfileCardUser(
+            isDarkTheme: isDarkTheme,
+            profileImageData: profileImageData,
+            userName: userName,
+            occupation: occupation,
+            profileCardTheme: profileCardTheme
+        )
+    }
+}
+
+@MainActor
+class KMPViewEmbedder {
+    static let shared = KMPViewEmbedder()
+    var implementation: KMPViewEmbedderProtocol?
+    
+    func embedInViewController(viewController: UIViewController, kmpView: Any) {
+        guard let impl = implementation else {
+            // 実装が設定されていない場合は、ダミーのViewを追加
+            print("Warning: KMPViewEmbedder implementation not set")
+            let dummyView = UIView()
+            dummyView.backgroundColor = .systemGray6
+            dummyView.translatesAutoresizingMaskIntoConstraints = false
+            viewController.view.addSubview(dummyView)
+            NSLayoutConstraint.activate([
+                dummyView.centerXAnchor.constraint(equalTo: viewController.view.centerXAnchor),
+                dummyView.centerYAnchor.constraint(equalTo: viewController.view.centerYAnchor),
+                dummyView.widthAnchor.constraint(equalToConstant: 150),
+                dummyView.heightAnchor.constraint(equalToConstant: 200)
+            ])
+            return
+        }
+        impl.embedInViewController(viewController: viewController, kmpView: kmpView)
+    }
+}

--- a/app-ios/Native/Sources/Feature/ProfileCard/Components/FrontCard.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/Components/FrontCard.swift
@@ -1,21 +1,24 @@
 import SwiftUI
 import Theme
+import Model
 
 struct FrontCard: View {
     let userRole: String
     let userName: String
     let cardType: ProfileCardType
+    let cardVariant: ProfileCardVariant
     let image: Data
     let normal: (Float, Float, Float)
     let effectEnabled: Bool
 
     init(
-        userRole: String, userName: String, cardType: ProfileCardType, image: Data,
+        userRole: String, userName: String, cardType: ProfileCardType, cardVariant: ProfileCardVariant, image: Data,
         normal: (Float, Float, Float) = (0, 0, 0), effectEnabled: Bool = true
     ) {
         self.userRole = userRole
         self.userName = userName
         self.cardType = cardType
+        self.cardVariant = cardVariant
         self.image = image
         self.normal = normal
         self.effectEnabled = effectEnabled
@@ -82,10 +85,41 @@ struct FrontCard: View {
         .clipped(antialiased: true)
     }
 
+    // Compose Multiplatformを使用したMaterial3 Shape適用版
+    // KMPのProfileCardUserコンポーネントを利用
+    @ViewBuilder
     private var avatarImage: some View {
-        Image(uiImage: UIImage(data: image)!)
-            .resizable()
-            .frame(width: 131, height: 131)
-            .foregroundColor(.accentColor)
+        // KMPのCompose UIをSwiftUIに埋め込む
+        ComposeView(
+            content: {
+                ProfileCardUserView(
+                    isDarkTheme: cardType == .night,
+                    profileImageData: image,
+                    userName: userName,
+                    occupation: userRole,
+                    profileCardTheme: mapToKMPTheme(cardVariant)
+                )
+            }
+        )
+        .frame(width: 150, height: 150) // 画像部分のみのサイズに調整
+    }
+
+    // ProfileCardVariantをKMPのProfileCardThemeにマッピング
+    private func mapToKMPTheme(_ variant: ProfileCardVariant) -> String {
+        // KMPのProfileCardThemeにマッピング
+        switch variant {
+        case .dayPill:
+            return "LightPill"
+        case .nightPill:
+            return "DarkPill"
+        case .dayDiamond:
+            return "LightDiamond"
+        case .nightDiamond:
+            return "DarkDiamond"
+        case .dayFlower:
+            return "LightFlower"
+        case .nightFlower:
+            return "DarkFlower"
+        }
     }
 }

--- a/app-ios/Native/Sources/Feature/ProfileCard/Components/KMPProfileCardInitializer.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/Components/KMPProfileCardInitializer.swift
@@ -1,0 +1,81 @@
+import Foundation
+import UIKit
+import shared
+
+/**
+ * KMPとSwiftUIのブリッジを初期化
+ * アプリ起動時に呼び出す
+ */
+@MainActor
+public class KMPProfileCardInitializer {
+    
+    public static func initialize() {
+        // KMPProfileCardUserFactoryの実装を設定
+        KMPProfileCardUserFactory.shared.implementation = KMPProfileCardUserFactoryImpl()
+        
+        // KMPViewEmbedderの実装を設定
+        KMPViewEmbedder.shared.implementation = KMPViewEmbedderImpl()
+    }
+}
+
+// KMPProfileCardUserFactoryの実装
+@MainActor
+private class KMPProfileCardUserFactoryImpl: NSObject, KMPProfileCardUserFactoryProtocol {
+    
+    func createProfileCardUser(
+        isDarkTheme: Bool,
+        profileImageData: Data,
+        userName: String,
+        occupation: String,
+        profileCardTheme: Any
+    ) -> Any {
+        // KMP側のcreateKMPProfileCardViewController関数を使用
+        guard let themeString = profileCardTheme as? String else {
+            print("Error: profileCardTheme should be String, got \(type(of: profileCardTheme))")
+            // エラー時は空のViewControllerを返す
+            let errorViewController = UIViewController()
+            errorViewController.view.backgroundColor = UIColor.clear
+            return errorViewController
+        }
+        
+        return ProfileCardIOSBridgeKt.createKMPProfileCardViewController(
+            isDarkTheme: isDarkTheme,
+            profileImageData: (profileImageData as NSData) as Data,
+            userName: userName,
+            occupation: occupation,
+            profileCardTheme: themeString
+        )
+    }
+}
+
+// KMPViewEmbedderの実装
+@MainActor
+private class KMPViewEmbedderImpl: NSObject, KMPViewEmbedderProtocol {
+    
+    func embedInViewController(viewController: UIViewController, kmpView: Any) {
+        guard let kmpViewController = kmpView as? UIViewController else {
+            print("Warning: kmpView is not a UIViewController")
+            return
+        }
+        
+        // KMPのViewControllerを子ViewControllerとして追加
+        viewController.addChild(kmpViewController)
+        
+        // 背景を透明に設定
+        kmpViewController.view.backgroundColor = UIColor.clear
+        
+        kmpViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        viewController.view.addSubview(kmpViewController.view)
+        
+        // 制約を設定
+        NSLayoutConstraint.activate([
+            kmpViewController.view.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
+            kmpViewController.view.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
+            kmpViewController.view.topAnchor.constraint(equalTo: viewController.view.topAnchor),
+            kmpViewController.view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)
+        ])
+        
+        kmpViewController.didMove(toParent: viewController)
+    }
+}
+

--- a/app-ios/Native/Sources/Feature/ProfileCard/Components/Material3Shapes.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/Components/Material3Shapes.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+enum Material3ShapeType: String, CaseIterable {
+    case pill
+    case diamond
+    case flower
+}
+
+struct Material3Shape: Shape {
+    let type: Material3ShapeType
+    
+    func path(in rect: CGRect) -> Path {
+        switch type {
+        case .pill:
+            return pillPath(in: rect)
+        case .diamond:
+            return diamondPath(in: rect)
+        case .flower:
+            return flowerPath(in: rect)
+        }
+    }
+    
+    private func pillPath(in rect: CGRect) -> Path {
+        Path(roundedRect: rect, cornerRadius: min(rect.width, rect.height) / 2)
+    }
+    
+    private func diamondPath(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        
+        path.move(to: CGPoint(x: center.x, y: center.y - radius))
+        path.addLine(to: CGPoint(x: center.x + radius, y: center.y))
+        path.addLine(to: CGPoint(x: center.x, y: center.y + radius))
+        path.addLine(to: CGPoint(x: center.x - radius, y: center.y))
+        path.closeSubpath()
+        
+        return path
+    }
+    
+    private func flowerPath(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        let petalRadius = radius * 0.35
+        let petalCount = 6
+        
+        for i in 0..<petalCount {
+            let angle = (CGFloat(i) * 2 * .pi) / CGFloat(petalCount)
+            let petalCenter = CGPoint(
+                x: center.x + cos(angle) * (radius - petalRadius),
+                y: center.y + sin(angle) * (radius - petalRadius)
+            )
+            
+            if i == 0 {
+                path.move(to: petalCenter)
+            }
+            
+            let controlAngle1 = angle - .pi / CGFloat(petalCount)
+            let controlAngle2 = angle + .pi / CGFloat(petalCount)
+            
+            let control1 = CGPoint(
+                x: center.x + cos(controlAngle1) * radius * 1.1,
+                y: center.y + sin(controlAngle1) * radius * 1.1
+            )
+            let control2 = CGPoint(
+                x: center.x + cos(controlAngle2) * radius * 1.1,
+                y: center.y + sin(controlAngle2) * radius * 1.1
+            )
+            
+            let nextAngle = (CGFloat(i + 1) * 2 * .pi) / CGFloat(petalCount)
+            let nextPetalCenter = CGPoint(
+                x: center.x + cos(nextAngle) * (radius - petalRadius),
+                y: center.y + sin(nextAngle) * (radius - petalRadius)
+            )
+            
+            path.addCurve(
+                to: nextPetalCenter,
+                control1: control1,
+                control2: control2
+            )
+        }
+        
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct Material3ClippedImage: View {
+    let imageName: String?
+    let systemImageName: String?
+    let bundle: Bundle?
+    let shapeType: Material3ShapeType
+    let size: CGFloat
+    
+    init(
+        imageName: String? = nil,
+        systemImageName: String? = nil,
+        bundle: Bundle? = nil,
+        shapeType: Material3ShapeType,
+        size: CGFloat
+    ) {
+        self.imageName = imageName
+        self.systemImageName = systemImageName
+        self.bundle = bundle
+        self.shapeType = shapeType
+        self.size = size
+    }
+    
+    var body: some View {
+        Group {
+            if let imageName = imageName {
+                Image(imageName, bundle: bundle)
+                    .resizable()
+                    .scaledToFill()
+            } else if let systemImageName = systemImageName {
+                Image(systemName: systemImageName)
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundColor(.accentColor)
+                    .padding(size * 0.2)
+                    .background(Color.gray.opacity(0.2))
+            } else {
+                Color.gray.opacity(0.3)
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Material3Shape(type: shapeType))
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        HStack(spacing: 20) {
+            Material3ClippedImage(
+                systemImageName: "person.circle.fill",
+                shapeType: .pill,
+                size: 100
+            )
+            Material3ClippedImage(
+                systemImageName: "person.circle.fill",
+                shapeType: .diamond,
+                size: 100
+            )
+            Material3ClippedImage(
+                systemImageName: "person.circle.fill",
+                shapeType: .flower,
+                size: 100
+            )
+        }
+        
+        HStack(spacing: 20) {
+            ForEach(Material3ShapeType.allCases, id: \.self) { shape in
+                VStack {
+                    Material3Shape(type: shape)
+                        .stroke(Color.blue, lineWidth: 2)
+                        .frame(width: 80, height: 80)
+                    Text(shape.rawValue.capitalized)
+                        .font(.caption)
+                }
+            }
+        }
+    }
+    .padding()
+}

--- a/app-ios/Native/Sources/Feature/ProfileCard/Components/Material3Shapes.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/Components/Material3Shapes.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Model
 
 enum Material3ShapeType: String, CaseIterable {
     case pill
@@ -6,9 +7,24 @@ enum Material3ShapeType: String, CaseIterable {
     case flower
 }
 
+extension Material3ShapeType {
+    init(from cardVariant: ProfileCardVariant) {
+        print("Material3ShapeType.init: cardVariant = \(cardVariant), shape = \(cardVariant.shape)")
+        switch cardVariant.shape {
+        case .pill:
+            self = .pill
+        case .diamond:
+            self = .diamond
+        case .flower:
+            self = .flower
+        }
+        print("Material3ShapeType.init: result = \(self)")
+    }
+}
+
 struct Material3Shape: Shape {
     let type: Material3ShapeType
-    
+
     func path(in rect: CGRect) -> Path {
         switch type {
         case .pill:
@@ -19,69 +35,256 @@ struct Material3Shape: Shape {
             return flowerPath(in: rect)
         }
     }
-    
+
     private func pillPath(in rect: CGRect) -> Path {
-        Path(roundedRect: rect, cornerRadius: min(rect.width, rect.height) / 2)
-    }
-    
-    private func diamondPath(in rect: CGRect) -> Path {
         var path = Path()
+        let size = min(rect.width, rect.height)
         let center = CGPoint(x: rect.midX, y: rect.midY)
-        let radius = min(rect.width, rect.height) / 2
-        
-        path.move(to: CGPoint(x: center.x, y: center.y - radius))
-        path.addLine(to: CGPoint(x: center.x + radius, y: center.y))
-        path.addLine(to: CGPoint(x: center.x, y: center.y + radius))
-        path.addLine(to: CGPoint(x: center.x - radius, y: center.y))
+
+        let scale = size / 250.0
+        let rotationAngle: CGFloat = 310 * .pi / 180
+
+        let pillLength = 267 * scale
+        let pillWidth = 200 * scale
+        let radius = pillWidth / 2
+
+        var pillPath = Path()
+
+        let startX = -pillLength / 2 + radius
+        let startY = -radius
+
+        pillPath.move(to: CGPoint(x: startX, y: startY))
+        pillPath.addLine(to: CGPoint(x: pillLength / 2 - radius, y: -radius))
+
+        pillPath.addArc(
+            center: CGPoint(x: pillLength / 2 - radius, y: 0),
+            radius: radius,
+            startAngle: .degrees(-90),
+            endAngle: .degrees(90),
+            clockwise: false
+        )
+
+        pillPath.addLine(to: CGPoint(x: -pillLength / 2 + radius, y: radius))
+
+        pillPath.addArc(
+            center: CGPoint(x: -pillLength / 2 + radius, y: 0),
+            radius: radius,
+            startAngle: .degrees(90),
+            endAngle: .degrees(270),
+            clockwise: false
+        )
+
+        pillPath.closeSubpath()
+
+        let transform = CGAffineTransform(translationX: center.x, y: center.y)
+            .rotated(by: rotationAngle)
+
+        return pillPath.applying(transform)
+    }
+
+    private func diamondPath(in rect: CGRect) -> Path {
+        // Material 3 Diamond shape - based on SVG path, creates an octagonal diamond
+        var path = Path()
+        let size = min(rect.width, rect.height)
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+
+        // Scale coordinates from SVG (380x380) to our rect
+        let scale = size / 380.0
+
+        // Convert SVG coordinates to our coordinate system, centered
+        let svgCenterX: CGFloat = 190 // SVG center (380/2)
+        let svgCenterY: CGFloat = 190 // SVG center (380/2)
+
+        func convertSVGPoint(x: CGFloat, y: CGFloat) -> CGPoint {
+            let scaledX = (x - svgCenterX) * scale + center.x
+            let scaledY = (y - svgCenterY) * scale + center.y
+            return CGPoint(x: scaledX, y: scaledY)
+        }
+
+        // Diamond quadrilateral shape with 4 rounded corners
+        // Adjusted proportions: height x2, width x1.3
+
+        let baseWidth = 160.0  // Original: ~160 (350-30 = 320, half = 160)
+        let baseHeight = 160.0 // Original: ~160 (350-30 = 320, half = 160)
+
+        let adjustedWidth = baseWidth * 1.30
+        let adjustedHeight = baseHeight * 1.40
+
+        let points = [
+            convertSVGPoint(x: 190, y: 190 - adjustedHeight),    // Top
+            convertSVGPoint(x: 190 + adjustedWidth, y: 190),     // Right
+            convertSVGPoint(x: 190, y: 190 + adjustedHeight),    // Bottom
+            convertSVGPoint(x: 190 - adjustedWidth, y: 190)      // Left
+        ]
+
+        guard points.count == 4 else { return path }
+
+        let cornerRadius: CGFloat = 80 * scale // Rounded corner radius
+
+        // Calculate all corner points first
+        var cornerSegments: [(start: CGPoint, end: CGPoint, control: CGPoint)] = []
+
+        for i in 0..<4 {
+            let currentPoint = points[i]
+            let nextPoint = points[(i + 1) % 4]
+            let prevPoint = points[(i + 3) % 4]
+
+            // Direction vectors
+            let dirFromPrev = CGPoint(
+                x: currentPoint.x - prevPoint.x,
+                y: currentPoint.y - prevPoint.y
+            )
+            let dirToNext = CGPoint(
+                x: nextPoint.x - currentPoint.x,
+                y: nextPoint.y - currentPoint.y
+            )
+
+            // Normalize directions
+            let lengthFromPrev = sqrt(dirFromPrev.x * dirFromPrev.x + dirFromPrev.y * dirFromPrev.y)
+            let lengthToNext = sqrt(dirToNext.x * dirToNext.x + dirToNext.y * dirToNext.y)
+
+            let normalizedFromPrev = CGPoint(
+                x: dirFromPrev.x / lengthFromPrev,
+                y: dirFromPrev.y / lengthFromPrev
+            )
+            let normalizedToNext = CGPoint(
+                x: dirToNext.x / lengthToNext,
+                y: dirToNext.y / lengthToNext
+            )
+
+            // Points before and after corner
+            let beforeCorner = CGPoint(
+                x: currentPoint.x - normalizedFromPrev.x * cornerRadius,
+                y: currentPoint.y - normalizedFromPrev.y * cornerRadius
+            )
+            let afterCorner = CGPoint(
+                x: currentPoint.x + normalizedToNext.x * cornerRadius,
+                y: currentPoint.y + normalizedToNext.y * cornerRadius
+            )
+
+            cornerSegments.append((start: beforeCorner, end: afterCorner, control: currentPoint))
+        }
+
+        // Start from the first segment's start point
+        path.move(to: cornerSegments[0].start)
+
+        // Draw all segments
+        for i in 0..<4 {
+            let currentSegment = cornerSegments[i]
+            let nextSegment = cornerSegments[(i + 1) % 4]
+
+            // Draw the rounded corner
+            path.addQuadCurve(to: currentSegment.end, control: currentSegment.control)
+
+            // Draw line to next segment's start (if not the last segment)
+            if i < 3 {
+                path.addLine(to: nextSegment.start)
+            }
+        }
+
         path.closeSubpath()
-        
+
         return path
     }
-    
+
     private func flowerPath(in rect: CGRect) -> Path {
+        // Material 3 Flower shape - based on SVG, creates a complex star/flower with curved petals
         var path = Path()
+        let size = min(rect.width, rect.height)
         let center = CGPoint(x: rect.midX, y: rect.midY)
-        let radius = min(rect.width, rect.height) / 2
-        let petalRadius = radius * 0.35
-        let petalCount = 6
-        
-        for i in 0..<petalCount {
-            let angle = (CGFloat(i) * 2 * .pi) / CGFloat(petalCount)
-            let petalCenter = CGPoint(
-                x: center.x + cos(angle) * (radius - petalRadius),
-                y: center.y + sin(angle) * (radius - petalRadius)
-            )
-            
-            if i == 0 {
-                path.move(to: petalCenter)
-            }
-            
-            let controlAngle1 = angle - .pi / CGFloat(petalCount)
-            let controlAngle2 = angle + .pi / CGFloat(petalCount)
-            
-            let control1 = CGPoint(
-                x: center.x + cos(controlAngle1) * radius * 1.1,
-                y: center.y + sin(controlAngle1) * radius * 1.1
-            )
-            let control2 = CGPoint(
-                x: center.x + cos(controlAngle2) * radius * 1.1,
-                y: center.y + sin(controlAngle2) * radius * 1.1
-            )
-            
-            let nextAngle = (CGFloat(i + 1) * 2 * .pi) / CGFloat(petalCount)
-            let nextPetalCenter = CGPoint(
-                x: center.x + cos(nextAngle) * (radius - petalRadius),
-                y: center.y + sin(nextAngle) * (radius - petalRadius)
-            )
-            
-            path.addCurve(
-                to: nextPetalCenter,
-                control1: control1,
-                control2: control2
-            )
+        let scale = size / 200.0
+
+        // Convert SVG coordinates to our coordinate system, centered
+        let svgCenterX: CGFloat = 190 // SVG center
+        let svgCenterY: CGFloat = 190 // SVG center
+
+        func convertSVGPoint(x: CGFloat, y: CGFloat) -> CGPoint {
+            let scaledX = (x - svgCenterX) * scale + center.x
+            let scaledY = (y - svgCenterY) * scale + center.y
+            return CGPoint(x: scaledX, y: scaledY)
         }
-        
+
+        // Create flower shape with 8 onigiri-shaped petals
+        let petalCount = 8
+        let outerRadius = size / 2 * 0.9
+        let innerRadius = size / 2 * 0.3  // Smaller inner radius for more triangular shape
+
+        // Start from center and draw onigiri-shaped petals
+        path.move(to: center)
+
+        for i in 0..<petalCount {
+            let petalAngle = CGFloat(i) * 2 * .pi / CGFloat(petalCount)
+            let halfPetalAngle = .pi / CGFloat(petalCount)
+
+            // Onigiri shape: wide base at center, narrow sides, rounded top
+            let tipPoint = CGPoint(
+                x: center.x + cos(petalAngle) * outerRadius,
+                y: center.y + sin(petalAngle) * outerRadius
+            )
+
+            // Base points (wider at the bottom like onigiri)
+            let baseWidth = innerRadius * 1.5
+            let leftBaseAngle = petalAngle - halfPetalAngle * 0.8
+            let rightBaseAngle = petalAngle + halfPetalAngle * 0.8
+
+            let leftBase = CGPoint(
+                x: center.x + cos(leftBaseAngle) * baseWidth,
+                y: center.y + sin(leftBaseAngle) * baseWidth
+            )
+            let rightBase = CGPoint(
+                x: center.x + cos(rightBaseAngle) * baseWidth,
+                y: center.y + sin(rightBaseAngle) * baseWidth
+            )
+
+            // Side points for onigiri shape (narrowing toward tip)
+            let sideRadius = outerRadius * 0.6
+            let leftSide = CGPoint(
+                x: center.x + cos(petalAngle - halfPetalAngle * 0.4) * sideRadius,
+                y: center.y + sin(petalAngle - halfPetalAngle * 0.4) * sideRadius
+            )
+            let rightSide = CGPoint(
+                x: center.x + cos(petalAngle + halfPetalAngle * 0.4) * sideRadius,
+                y: center.y + sin(petalAngle + halfPetalAngle * 0.4) * sideRadius
+            )
+
+            if i == 0 {
+                // Move to first left base
+                path.move(to: leftBase)
+            } else {
+                // Connect from previous petal
+                path.addLine(to: leftBase)
+            }
+
+            // Draw onigiri-shaped petal
+            // Left side: curve from base to side point
+            path.addQuadCurve(to: leftSide, control: CGPoint(
+                x: leftBase.x + (leftSide.x - leftBase.x) * 0.3,
+                y: leftBase.y + (leftSide.y - leftBase.y) * 0.3
+            ))
+
+            // Top: rounded curve to tip
+            let tipControlRadius = outerRadius * 0.8
+            let tipControl = CGPoint(
+                x: center.x + cos(petalAngle) * tipControlRadius,
+                y: center.y + sin(petalAngle) * tipControlRadius
+            )
+            path.addQuadCurve(to: tipPoint, control: tipControl)
+
+            // Right side: curve from tip to right side
+            path.addQuadCurve(to: rightSide, control: CGPoint(
+                x: tipPoint.x + (rightSide.x - tipPoint.x) * 0.3,
+                y: tipPoint.y + (rightSide.y - tipPoint.y) * 0.3
+            ))
+
+            // Bottom right: curve to right base
+            path.addQuadCurve(to: rightBase, control: CGPoint(
+                x: rightSide.x + (rightBase.x - rightSide.x) * 0.7,
+                y: rightSide.y + (rightBase.y - rightSide.y) * 0.7
+            ))
+        }
+
         path.closeSubpath()
+
         return path
     }
 }
@@ -92,7 +295,7 @@ struct Material3ClippedImage: View {
     let bundle: Bundle?
     let shapeType: Material3ShapeType
     let size: CGFloat
-    
+
     init(
         imageName: String? = nil,
         systemImageName: String? = nil,
@@ -106,7 +309,7 @@ struct Material3ClippedImage: View {
         self.shapeType = shapeType
         self.size = size
     }
-    
+
     var body: some View {
         Group {
             if let imageName = imageName {
@@ -148,7 +351,7 @@ struct Material3ClippedImage: View {
                 size: 100
             )
         }
-        
+
         HStack(spacing: 20) {
             ForEach(Material3ShapeType.allCases, id: \.self) { shape in
                 VStack {

--- a/app-ios/Native/Sources/Feature/ProfileCard/Components/OGPProfileShareImage.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/Components/OGPProfileShareImage.swift
@@ -9,7 +9,7 @@ public struct OGPProfileShareImage: View {
             Image(profile.cardVariant.type == .day ? .nightOgpBase : .dayOgpBase)
                 .resizable()
             FrontCard(
-                userRole: profile.occupation, userName: profile.name, cardType: profile.cardVariant.type,
+                userRole: profile.occupation, userName: profile.name, cardType: profile.cardVariant.type, cardVariant: <#ProfileCardVariant#>,
                 image: profile.image, effectEnabled: false
             )
             .offset(x: 280, y: 60)

--- a/app-ios/Native/Sources/Feature/ProfileCard/Components/OGPProfileShareImage.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/Components/OGPProfileShareImage.swift
@@ -9,7 +9,7 @@ public struct OGPProfileShareImage: View {
             Image(profile.cardVariant.type == .day ? .nightOgpBase : .dayOgpBase)
                 .resizable()
             FrontCard(
-                userRole: profile.occupation, userName: profile.name, cardType: profile.cardVariant.type, cardVariant: <#ProfileCardVariant#>,
+                userRole: profile.occupation, userName: profile.name, cardType: profile.cardVariant.type, cardVariant: profile.cardVariant,
                 image: profile.image, effectEnabled: false
             )
             .offset(x: 280, y: 60)

--- a/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardPresenter.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardPresenter.swift
@@ -96,9 +96,19 @@ final class ProfileCardPresenter {
         if !formState.validate() { return }
 
         Task {
-            let profileData = try await formState.createProfile()
-            profile.saveProfile(profileData)
-            self.isEditing = false
+            do {
+                let profileData = try await formState.createProfile()
+                print("ProfileCardPresenter.createCard: Created profile with cardVariant = \(profileData.cardVariant)")
+                await MainActor.run {
+                    profile.saveProfile(profileData)
+                }
+            } catch {
+                print("ProfileCardPresenter.createCard: Error creating profile: \(error)")
+                await MainActor.run {
+                    // If there's an error, go back to editing mode
+                    self.isEditing = true
+                }
+            }
         }
     }
 
@@ -119,6 +129,8 @@ final class ProfileCardPresenter {
     }
 
     func setCardVariant(_ variant: ProfileCardVariant) {
+        print("ProfileCardPresenter.setCardVariant: Setting cardVariant from \(formState.cardVariant) to \(variant)")
         formState.cardVariant = variant
+        print("ProfileCardPresenter.setCardVariant: Updated formState.cardVariant = \(formState.cardVariant)")
     }
 }

--- a/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardScreen.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardScreen.swift
@@ -136,58 +136,6 @@ public struct ProfileCardScreen: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 20)
     }
-    
-    private var shapeSelector: some View {
-        VStack(spacing: 12) {
-            Text("Profile Shape")
-                .foregroundStyle(AssetColors.onSurface.swiftUIColor)
-                .typographyStyle(.titleMedium)
-            
-            HStack(spacing: 20) {
-                ForEach(Material3ShapeType.allCases, id: \.self) { shape in
-                    Button {
-                        selectedShape = shape
-                    } label: {
-                        VStack(spacing: 8) {
-                            Material3ClippedImage(
-                                systemImageName: "person.circle.fill",
-                                shapeType: shape,
-                                size: 60
-                            )
-                            .scaleEffect(selectedShape == shape ? 1.1 : 1.0)
-                            .animation(.easeInOut(duration: 0.2), value: selectedShape)
-                            
-                            Text(shape.rawValue.capitalized)
-                                .font(.caption)
-                                .foregroundStyle(
-                                    selectedShape == shape 
-                                    ? AssetColors.primary.swiftUIColor 
-                                    : AssetColors.onSurfaceVariant.swiftUIColor
-                                )
-                        }
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(selectedShape == shape 
-                                      ? AssetColors.primaryContainer.swiftUIColor.opacity(0.3)
-                                      : Color.clear)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(selectedShape == shape 
-                                        ? AssetColors.primary.swiftUIColor 
-                                        : Color.clear, 
-                                        lineWidth: 2)
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 20)
-    }
 
     private var shareButton: some View {
         let uiImage = OGPProfileShareImage(profile: presenter.profile.profile!).render()!

--- a/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardScreen.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardScreen.swift
@@ -7,6 +7,7 @@ import Theme
 
 public struct ProfileCardScreen: View {
     @State private var presenter = ProfileCardPresenter()
+    @State private var selectedShape: Material3ShapeType = .pill
 
     public init() {}
 
@@ -36,24 +37,19 @@ public struct ProfileCardScreen: View {
                 } else if presenter.shouldEditing {
                     editView
                 } else {
-                    cardView(profile!)
+                    VStack(spacing: 0) {
+                        profileCard(profile!)
+                        shapeSelector
+                        actionButtons
+                    }
+                    .padding(.vertical, 20)
                 }
             }
-            .padding(.bottom, 80)  // Tab bar padding
         }
     }
 
     private var editView: some View {
         EditProfileCardForm(presenter: $presenter)
-    }
-
-    @ViewBuilder
-    private func cardView(_ profile: Model.Profile) -> some View {
-        VStack(spacing: 0) {
-            profileCard(profile)
-            actionButtons
-        }
-        .padding(.vertical, 20)
     }
 
     @ViewBuilder
@@ -65,7 +61,7 @@ public struct ProfileCardScreen: View {
                     userName: profile.name,
                     cardType: profile.cardVariant.type,
                     image: profile.image,
-                    normal: (normal.x, normal.y, normal.z),
+                    normal: (normal.x, normal.y, normal.z)
                 )
             },
             back: { normal in
@@ -87,6 +83,110 @@ public struct ProfileCardScreen: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
+    }
+    
+    private var shapeSelector: some View {
+        VStack(spacing: 12) {
+            Text("Profile Shape")
+                .foregroundStyle(AssetColors.onSurface.swiftUIColor)
+                .typographyStyle(.titleMedium)
+            
+            HStack(spacing: 20) {
+                ForEach(Material3ShapeType.allCases, id: \.self) { shape in
+                    Button {
+                        selectedShape = shape
+                    } label: {
+                        VStack(spacing: 8) {
+                            Material3ClippedImage(
+                                systemImageName: "person.circle.fill",
+                                shapeType: shape,
+                                size: 60
+                            )
+                            .scaleEffect(selectedShape == shape ? 1.1 : 1.0)
+                            .animation(.easeInOut(duration: 0.2), value: selectedShape)
+                            
+                            Text(shape.rawValue.capitalized)
+                                .font(.caption)
+                                .foregroundStyle(
+                                    selectedShape == shape 
+                                    ? AssetColors.primary.swiftUIColor 
+                                    : AssetColors.onSurfaceVariant.swiftUIColor
+                                )
+                        }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(selectedShape == shape 
+                                      ? AssetColors.primaryContainer.swiftUIColor.opacity(0.3)
+                                      : Color.clear)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(selectedShape == shape 
+                                        ? AssetColors.primary.swiftUIColor 
+                                        : Color.clear, 
+                                        lineWidth: 2)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 20)
+    }
+    
+    private var shapeSelector: some View {
+        VStack(spacing: 12) {
+            Text("Profile Shape")
+                .foregroundStyle(AssetColors.onSurface.swiftUIColor)
+                .typographyStyle(.titleMedium)
+            
+            HStack(spacing: 20) {
+                ForEach(Material3ShapeType.allCases, id: \.self) { shape in
+                    Button {
+                        selectedShape = shape
+                    } label: {
+                        VStack(spacing: 8) {
+                            Material3ClippedImage(
+                                systemImageName: "person.circle.fill",
+                                shapeType: shape,
+                                size: 60
+                            )
+                            .scaleEffect(selectedShape == shape ? 1.1 : 1.0)
+                            .animation(.easeInOut(duration: 0.2), value: selectedShape)
+                            
+                            Text(shape.rawValue.capitalized)
+                                .font(.caption)
+                                .foregroundStyle(
+                                    selectedShape == shape 
+                                    ? AssetColors.primary.swiftUIColor 
+                                    : AssetColors.onSurfaceVariant.swiftUIColor
+                                )
+                        }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(selectedShape == shape 
+                                      ? AssetColors.primaryContainer.swiftUIColor.opacity(0.3)
+                                      : Color.clear)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(selectedShape == shape 
+                                        ? AssetColors.primary.swiftUIColor 
+                                        : Color.clear, 
+                                        lineWidth: 2)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 20)
     }
 
     private var shareButton: some View {

--- a/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardScreen.swift
+++ b/app-ios/Native/Sources/Feature/ProfileCard/ProfileCardScreen.swift
@@ -7,7 +7,6 @@ import Theme
 
 public struct ProfileCardScreen: View {
     @State private var presenter = ProfileCardPresenter()
-    @State private var selectedShape: Material3ShapeType = .pill
 
     public init() {}
 
@@ -39,13 +38,14 @@ public struct ProfileCardScreen: View {
                 } else {
                     VStack(spacing: 0) {
                         profileCard(profile!)
-                        shapeSelector
                         actionButtons
                     }
                     .padding(.vertical, 20)
                 }
             }
         }
+        .contentShape(Rectangle())
+        .allowsHitTesting(true)
     }
 
     private var editView: some View {
@@ -60,6 +60,7 @@ public struct ProfileCardScreen: View {
                     userRole: profile.occupation,
                     userName: profile.name,
                     cardType: profile.cardVariant.type,
+                    cardVariant: profile.cardVariant,
                     image: profile.image,
                     normal: (normal.x, normal.y, normal.z)
                 )
@@ -83,58 +84,6 @@ public struct ProfileCardScreen: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
-    }
-    
-    private var shapeSelector: some View {
-        VStack(spacing: 12) {
-            Text("Profile Shape")
-                .foregroundStyle(AssetColors.onSurface.swiftUIColor)
-                .typographyStyle(.titleMedium)
-            
-            HStack(spacing: 20) {
-                ForEach(Material3ShapeType.allCases, id: \.self) { shape in
-                    Button {
-                        selectedShape = shape
-                    } label: {
-                        VStack(spacing: 8) {
-                            Material3ClippedImage(
-                                systemImageName: "person.circle.fill",
-                                shapeType: shape,
-                                size: 60
-                            )
-                            .scaleEffect(selectedShape == shape ? 1.1 : 1.0)
-                            .animation(.easeInOut(duration: 0.2), value: selectedShape)
-                            
-                            Text(shape.rawValue.capitalized)
-                                .font(.caption)
-                                .foregroundStyle(
-                                    selectedShape == shape 
-                                    ? AssetColors.primary.swiftUIColor 
-                                    : AssetColors.onSurfaceVariant.swiftUIColor
-                                )
-                        }
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(selectedShape == shape 
-                                      ? AssetColors.primaryContainer.swiftUIColor.opacity(0.3)
-                                      : Color.clear)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(selectedShape == shape 
-                                        ? AssetColors.primary.swiftUIColor 
-                                        : Color.clear, 
-                                        lineWidth: 2)
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 20)
     }
 
     private var shareButton: some View {

--- a/app-ios/Native/Sources/Root/KMPConverters.swift
+++ b/app-ios/Native/Sources/Root/KMPConverters.swift
@@ -354,7 +354,7 @@ extension Model.Staff {
             id: String(shared.id),
             name: shared.username,
             iconUrl: iconURL,
-            profileUrl: URL(string: shared.profileUrl),
+            profileUrl: shared.profileUrl.flatMap { URL(string: $0) },
             role: nil  // KMP Staff doesn't have role field
         )
     }

--- a/app-ios/Native/Sources/Root/KMPConverters.swift
+++ b/app-ios/Native/Sources/Root/KMPConverters.swift
@@ -346,15 +346,19 @@ extension Model.SponsorPlan {
 
 extension Model.Staff {
     init(from shared: shared.Staff) {
+        // TODO: Fix KMP property mapping when shared framework is updated
+        // Current issue: shared.Staff properties don't match expected interface
+        // Expected properties: id, username, iconUrl, profileUrl (from Kotlin source)
+        // Actual available properties in iOS: TBD - need KMP framework rebuild
+
         // Use FileManager URL as a safe fallback
         let fallbackURL = URL(fileURLWithPath: "/")
-        let iconURL = URL(string: shared.iconUrl) ?? fallbackURL
 
         self.init(
-            id: String(shared.id),
-            name: shared.name,
-            iconUrl: iconURL,
-            profileUrl: shared.profileUrl.flatMap { URL(string: $0) },
+            id: String(shared.id), // This should work as id is a basic property
+            name: "Staff Name", // TODO: Fix with shared.username when available
+            iconUrl: fallbackURL, // TODO: Fix with shared.iconUrl when available
+            profileUrl: fallbackURL, // TODO: Fix with shared.profileUrl when available
             role: nil  // KMP Staff doesn't have role field
         )
     }
@@ -364,16 +368,19 @@ extension Model.Staff {
 
 extension Model.Contributor {
     init(from shared: shared.Contributor) {
+        // TODO: Fix KMP property mapping when shared framework is updated
+        // Current issue: shared.Contributor properties don't match expected interface
+        // Expected properties: id, username, iconUrl, profileUrl (from Kotlin source)
+        // Actual available properties in iOS: TBD - need KMP framework rebuild
+
         // Use FileManager URL as a safe fallback
         let fallbackURL = URL(fileURLWithPath: "/")
-        let profileURL = shared.profileUrl.flatMap { URL(string: $0) }
-        let iconURL = URL(string: shared.iconUrl) ?? fallbackURL
 
         self.init(
-            id: String(shared.id),
-            name: shared.name,
-            url: profileURL ?? fallbackURL,
-            iconUrl: iconURL
+            id: String(shared.id), // This should work as id is a basic property
+            name: "Contributor Name", // TODO: Fix with shared.username when available
+            url: fallbackURL, // TODO: Fix with shared.profileUrl when available
+            iconUrl: fallbackURL // TODO: Fix with shared.iconUrl when available
         )
     }
 }

--- a/app-ios/Native/Sources/Root/KMPConverters.swift
+++ b/app-ios/Native/Sources/Root/KMPConverters.swift
@@ -352,7 +352,7 @@ extension Model.Staff {
 
         self.init(
             id: String(shared.id),
-            name: shared.username,
+            name: shared.name,
             iconUrl: iconURL,
             profileUrl: shared.profileUrl.flatMap { URL(string: $0) },
             role: nil  // KMP Staff doesn't have role field
@@ -371,7 +371,7 @@ extension Model.Contributor {
 
         self.init(
             id: String(shared.id),
-            name: shared.username,
+            name: shared.name,
             url: profileURL ?? fallbackURL,
             iconUrl: iconURL
         )

--- a/app-ios/Native/Sources/Root/KMPDependencyProvider.swift
+++ b/app-ios/Native/Sources/Root/KMPDependencyProvider.swift
@@ -6,8 +6,6 @@ public struct KMPDependencyProvider: Sendable {
     public let appGraph: shared.IosAppGraph
 
     private init() {
-        self.appGraph = IosAppGraphKt.createIosAppGraph(
-            useProductionApiBaseUrl: false
-        )
+        self.appGraph = IosAppGraphKt.createIosAppGraph()
     }
 }

--- a/app-ios/Native/Sources/Root/KMPDependencyProvider.swift
+++ b/app-ios/Native/Sources/Root/KMPDependencyProvider.swift
@@ -6,6 +6,12 @@ public struct KMPDependencyProvider: Sendable {
     public let appGraph: shared.IosAppGraph
 
     private init() {
-        self.appGraph = IosAppGraphKt.createIosAppGraph()
+        #if DEBUG
+        // Use staging API for debug builds
+        self.appGraph = IosAppGraphKt.createIosAppGraph(useProductionApiBaseUrl: false)
+        #else
+        // Use production API for release builds
+        self.appGraph = IosAppGraphKt.createIosAppGraph(useProductionApiBaseUrl: true)
+        #endif
     }
 }

--- a/app-ios/Native/Sources/Root/RootScreen.swift
+++ b/app-ios/Native/Sources/Root/RootScreen.swift
@@ -351,8 +351,12 @@ public struct RootScreen: View {
                         maxHeight: .infinity,
                         alignment: .center
                     )
+                    .contentShape(Rectangle())
+                    .allowsHitTesting(true)
                 }
             }
+            .contentShape(Rectangle())
+            .allowsHitTesting(true)
             .frame(width: geometry.size.width, height: geometry.size.height)
         }
         .frame(height: 64)

--- a/app-ios/Native/Sources/Root/RootScreen.swift
+++ b/app-ios/Native/Sources/Root/RootScreen.swift
@@ -61,7 +61,10 @@ public struct RootScreen: View {
             } else {
                 ZStack(alignment: .bottom) {
                     tabContent
+                        .padding(.bottom, 80)
                     tabBar
+                        .allowsHitTesting(true)
+                        .zIndex(1)
                 }
             }
         }
@@ -342,6 +345,7 @@ public struct RootScreen: View {
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                             .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                     .frame(
                         maxWidth: geometry.size.width / CGFloat(TabType.allCases.count),
                         maxHeight: .infinity,
@@ -356,8 +360,10 @@ public struct RootScreen: View {
         .padding(.horizontal, 12)
         .background(.ultraThinMaterial, in: Capsule())
         .overlay(Capsule().stroke(AssetColors.outline.swiftUIColor, lineWidth: 1))
+        .contentShape(Capsule())
         .environment(\.colorScheme, .dark)
         .padding(.horizontal, 48)
+        .allowsHitTesting(true)
     }
 }
 

--- a/app-shared/build.gradle.kts
+++ b/app-shared/build.gradle.kts
@@ -82,6 +82,7 @@ kotlin {
                 implementation(libs.molecule)
                 api(projects.feature.sessions)
                 api(projects.feature.contributors)
+                api(projects.feature.profile)
                 api(projects.core.model)
                 api(projects.core.data)
             }
@@ -135,6 +136,7 @@ kotlin {
 
                     export(projects.feature.sessions)
                     export(projects.feature.contributors)
+                    export(projects.feature.profile)
                     export(projects.core.model)
                     export(projects.core.data)
                     export(CommonComponentsDependencies.resources)

--- a/feature/profile/src/androidMain/kotlin/io/github/confsched/profile/ProfileCardAndroidBridge.kt
+++ b/feature/profile/src/androidMain/kotlin/io/github/confsched/profile/ProfileCardAndroidBridge.kt
@@ -1,0 +1,106 @@
+package io.github.confsched.profile
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.view.View
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import io.github.confsched.profile.components.ProfileCardUser
+import io.github.confsched.profile.components.shape
+import io.github.droidkaigi.confsched.model.profile.ProfileCardTheme
+
+/**
+ * Android用のプロフィールカードデータホルダー
+ */
+data class AndroidProfileCardData(
+    val isDarkTheme: Boolean,
+    val profileImageBitmap: ImageBitmap?,
+    val userName: String,
+    val occupation: String,
+    val profileCardTheme: ProfileCardTheme,
+)
+
+/**
+ * Android用のプロフィール画像データホルダー
+ */
+data class AndroidProfileImageData(
+    val profileImageBitmap: ImageBitmap?,
+    val profileCardTheme: ProfileCardTheme,
+)
+
+/**
+ * Android向けのProfileCard実装ブリッジ
+ * ComposableをAndroidビューとして提供
+ */
+class AndroidProfileCardBridge : ProfileCardBridgeInterface {
+
+    override fun createProfileCardUserView(
+        isDarkTheme: Boolean,
+        profileImageData: Any,
+        userName: String,
+        occupation: String,
+        profileCardTheme: String,
+    ): Any {
+        require(profileImageData is ByteArray) { "profileImageData must be ByteArray on Android" }
+
+        val imageBitmap = try {
+            profileImageData.toImageBitmap()
+        } catch (e: Exception) {
+            null
+        }
+
+        // Return a data holder that can be used by Composable functions
+        return AndroidProfileCardData(
+            isDarkTheme = isDarkTheme,
+            profileImageBitmap = imageBitmap,
+            userName = userName,
+            occupation = occupation,
+            profileCardTheme = profileCardTheme.toProfileCardTheme(),
+        )
+    }
+
+    override fun getSupportedThemes(): List<String> = listOf(
+        "LightPill",
+        "DarkPill",
+        "LightDiamond",
+        "DarkDiamond",
+        "LightFlower",
+        "DarkFlower",
+    )
+}
+
+/**
+ * Android向けのProfileCardBridgeインスタンス作成
+ */
+actual fun createProfileCardBridge(): ProfileCardBridgeInterface = AndroidProfileCardBridge()
+
+/**
+ * ByteArrayをImageBitmapに変換
+ */
+private fun ByteArray.toImageBitmap(): ImageBitmap {
+    val bitmap = BitmapFactory.decodeByteArray(this, 0, this.size)
+    return bitmap.asImageBitmap()
+}
+
+/**
+ * 文字列をProfileCardThemeに変換
+ */
+private fun String.toProfileCardTheme(): ProfileCardTheme {
+    return when (this) {
+        "LightPill" -> ProfileCardTheme.LightPill
+        "DarkPill" -> ProfileCardTheme.DarkPill
+        "LightDiamond" -> ProfileCardTheme.LightDiamond
+        "DarkDiamond" -> ProfileCardTheme.DarkDiamond
+        "LightFlower" -> ProfileCardTheme.LightFlower
+        "DarkFlower" -> ProfileCardTheme.DarkFlower
+        else -> ProfileCardTheme.LightPill // デフォルト
+    }
+}

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileCardBridgeInterface.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileCardBridgeInterface.kt
@@ -1,0 +1,30 @@
+package io.github.confsched.profile
+
+/**
+ * ProfileCard操作の共通インターフェース
+ * プラットフォーム固有の実装を抽象化
+ */
+interface ProfileCardBridgeInterface {
+
+    /**
+     * プロフィールカードのViewController/Viewを生成
+     * 戻り値の型は各プラットフォームで異なる（Any型で返す）
+     */
+    fun createProfileCardUserView(
+        isDarkTheme: Boolean,
+        profileImageData: Any, // NSData (iOS) or ByteArray (Android)
+        userName: String,
+        occupation: String,
+        profileCardTheme: String,
+    ): Any // UIViewController (iOS) or Composable (Android)
+
+    /**
+     * サポートされているテーマ名の一覧を取得
+     */
+    fun getSupportedThemes(): List<String>
+}
+
+/**
+ * プラットフォーム固有のProfileCardBridgeインスタンス取得
+ */
+expect fun createProfileCardBridge(): ProfileCardBridgeInterface

--- a/feature/profile/src/iosMain/kotlin/io/github/confsched/profile/ProfileCardIOSBridge.kt
+++ b/feature/profile/src/iosMain/kotlin/io/github/confsched/profile/ProfileCardIOSBridge.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -52,13 +53,17 @@ fun createKMPProfileCardViewController(
 /**
  * Material3 Shapeのみを適用した画像ViewControllerを作成
  */
-@OptIn(ExperimentalObjCName::class)
+@OptIn(ExperimentalObjCName::class, ExperimentalComposeUiApi::class)
 @ObjCName("createKMPProfileImageViewController")
 fun createKMPProfileImageViewController(
     profileImageData: NSData,
     profileCardTheme: String,
 ): UIViewController {
-    val controller = ComposeUIViewController {
+    val controller = ComposeUIViewController(
+        configure = {
+            opaque = false
+        },
+    ) {
         Box(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
@@ -86,7 +91,7 @@ object ProfileCardIOSBridge {
     /**
      * ProfileCardUserのiOS向けUIViewController生成
      */
-    @OptIn(ExperimentalObjCName::class)
+    @OptIn(ExperimentalObjCName::class, ExperimentalComposeUiApi::class)
     @ObjCName("createProfileCardUserViewController")
     fun createProfileCardUserViewController(
         isDarkTheme: Boolean,
@@ -95,7 +100,11 @@ object ProfileCardIOSBridge {
         occupation: String,
         profileCardTheme: String,
     ): UIViewController {
-        val controller = ComposeUIViewController {
+        val controller = ComposeUIViewController(
+            configure = {
+                opaque = false
+            },
+        ) {
             Box(
                 modifier = Modifier.background(Color.Transparent).fillMaxSize(),
                 contentAlignment = Alignment.Center,

--- a/feature/profile/src/iosMain/kotlin/io/github/confsched/profile/ProfileCardIOSBridge.kt
+++ b/feature/profile/src/iosMain/kotlin/io/github/confsched/profile/ProfileCardIOSBridge.kt
@@ -1,0 +1,288 @@
+package io.github.confsched.profile
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageBitmapConfig
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.ComposeUIViewController
+import io.github.confsched.profile.components.ProfileCardUser
+import io.github.confsched.profile.components.shape
+import io.github.droidkaigi.confsched.model.profile.ProfileCardTheme
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.UIKit.UIColor
+import platform.UIKit.UIViewController
+import platform.posix.memcpy
+import kotlin.experimental.ExperimentalObjCName
+import kotlin.native.ObjCName
+
+/**
+ * トップレベル関数としてProfileCardをSwiftから直接呼び出し可能にする
+ * SwiftUIからKMP Composeコンポーネントを利用するためのエントリーポイント
+ */
+@OptIn(ExperimentalObjCName::class)
+@ObjCName("createKMPProfileCardViewController")
+fun createKMPProfileCardViewController(
+    isDarkTheme: Boolean,
+    profileImageData: NSData,
+    userName: String,
+    occupation: String,
+    profileCardTheme: String,
+): UIViewController = ProfileCardIOSBridge.createProfileCardUserViewController(
+    isDarkTheme = isDarkTheme,
+    profileImageData = profileImageData,
+    userName = userName,
+    occupation = occupation,
+    profileCardTheme = profileCardTheme,
+)
+
+/**
+ * Material3 Shapeのみを適用した画像ViewControllerを作成
+ */
+@OptIn(ExperimentalObjCName::class)
+@ObjCName("createKMPProfileImageViewController")
+fun createKMPProfileImageViewController(
+    profileImageData: NSData,
+    profileCardTheme: String,
+): UIViewController {
+    val controller = ComposeUIViewController {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            ProfileCardIOSBridge.ProfileImageWithShape(
+                profileImageBitmap = profileImageData.toImageBitmap(),
+                profileCardTheme = profileCardTheme.toProfileCardTheme(),
+            )
+        }
+    }
+    // UIViewControllerとビューの背景を完全に透明に設定
+    controller.view.backgroundColor = UIColor.clearColor
+
+    return controller
+}
+
+/**
+ * iOS向けのProfileCard Material3 Shape実装ブリッジ
+ * SwiftUIからCompose Multiplatformのコンポーネントを利用可能にする
+ */
+@OptIn(ExperimentalObjCName::class)
+@ObjCName("KMPProfileCardIOSBridge")
+object ProfileCardIOSBridge {
+
+    /**
+     * ProfileCardUserのiOS向けUIViewController生成
+     */
+    @OptIn(ExperimentalObjCName::class)
+    @ObjCName("createProfileCardUserViewController")
+    fun createProfileCardUserViewController(
+        isDarkTheme: Boolean,
+        profileImageData: NSData,
+        userName: String,
+        occupation: String,
+        profileCardTheme: String,
+    ): UIViewController {
+        val controller = ComposeUIViewController {
+            Box(
+                modifier = Modifier.background(Color.Transparent).fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                val imageBitmap = try {
+                    profileImageData.toImageBitmap()
+                } catch (e: Exception) {
+                    null
+                }
+
+                if (imageBitmap != null) {
+                    ProfileImageWithShape(
+                        profileImageBitmap = imageBitmap,
+                        profileCardTheme = profileCardTheme.toProfileCardTheme(),
+                    )
+                } else {
+                    ProfileImageWithShapeTest(
+                        profileCardTheme = profileCardTheme.toProfileCardTheme(),
+                    )
+                }
+            }
+        }
+
+        // UIViewControllerとビューの背景を完全に透明に設定
+        controller.view.backgroundColor = UIColor.clearColor
+        controller.view.opaque = false // 不透明フラグをfalseに
+        controller.view.layer.opaque = false // レイヤーも透明に
+
+        return controller
+    }
+
+    /**
+     * Material3 Shapeを適用したProfileCardUserコンポーネント
+     */
+    @Composable
+    fun ProfileCardUserWithShape(
+        isDarkTheme: Boolean,
+        profileImageBitmap: ImageBitmap,
+        userName: String,
+        occupation: String,
+        profileCardTheme: ProfileCardTheme,
+    ) {
+        ProfileCardUser(
+            isDarkTheme = isDarkTheme,
+            profileImageBitmap = profileImageBitmap,
+            userName = userName,
+            occupation = occupation,
+            profileShape = profileCardTheme.shape, // Material3 Shapeを使用
+        )
+    }
+
+    /**
+     * 画像のみをMaterial3 Shapeでクリップしたコンポーネント
+     */
+    @Composable
+    fun ProfileImageWithShape(
+        profileImageBitmap: ImageBitmap,
+        profileCardTheme: ProfileCardTheme,
+        modifier: Modifier = Modifier,
+    ) {
+        Image(
+            bitmap = profileImageBitmap,
+            contentDescription = "Profile Image",
+            contentScale = ContentScale.Crop,
+            modifier = modifier
+                .size(150.dp)
+                .clip(profileCardTheme.shape)
+                .background(Color.Transparent),
+        )
+    }
+
+    /**
+     * テスト用：Material3形状のクロッピング動作確認用の色付きコンポーネント
+     */
+    @Composable
+    fun ProfileImageWithShapeTest(
+        profileCardTheme: ProfileCardTheme,
+        modifier: Modifier = Modifier,
+    ) {
+        Box(
+            modifier = modifier
+                .size(150.dp)
+                .clip(profileCardTheme.shape) // Material3 Shapeでクリップ
+                .background(
+                    when (profileCardTheme) {
+                        ProfileCardTheme.LightPill, ProfileCardTheme.DarkPill ->
+                            Color.Blue
+                        ProfileCardTheme.LightDiamond, ProfileCardTheme.DarkDiamond ->
+                            Color.Green
+                        ProfileCardTheme.LightFlower, ProfileCardTheme.DarkFlower ->
+                            Color.Red
+                    },
+                ),
+        )
+    }
+}
+
+/**
+ * 透明なImageBitmapを作成するヘルパー関数
+ */
+private fun createTransparentImageBitmap(width: Int, height: Int): ImageBitmap {
+    return androidx.compose.ui.graphics.ImageBitmap(
+        width = width,
+        height = height,
+        config = ImageBitmapConfig.Argb8888,
+        hasAlpha = true,
+    )
+}
+
+/**
+ * NSDataをImageBitmapに変換
+ * アルファチャンネルを保持してSkikoのImage.toComposeImageBitmap()を使用
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toImageBitmap(): ImageBitmap {
+    return try {
+        // 直接NSDataからSkikoのImageを作成（PNG変換を経由しない）
+        val bytes = ByteArray(this.length.toInt())
+        bytes.usePinned { pinned ->
+            memcpy(pinned.addressOf(0), this.bytes, this.length)
+        }
+
+        // SkikoのImageからImageBitmapを作成
+        val skikoImage = org.jetbrains.skia.Image.makeFromEncoded(bytes)
+        skikoImage.toComposeImageBitmap()
+    } catch (e: Exception) {
+        // 変換に失敗した場合は透明なプレースホルダーを返す
+        createTransparentImageBitmap(150, 150)
+    }
+}
+
+/**
+ * iOS向けの共通インターフェース実装
+ */
+@OptIn(ExperimentalObjCName::class)
+@ObjCName("IOSProfileCardBridge")
+class IOSProfileCardBridge : ProfileCardBridgeInterface {
+
+    override fun createProfileCardUserView(
+        isDarkTheme: Boolean,
+        profileImageData: Any,
+        userName: String,
+        occupation: String,
+        profileCardTheme: String,
+    ): Any {
+        require(profileImageData is NSData) { "profileImageData must be NSData on iOS" }
+        return ProfileCardIOSBridge.createProfileCardUserViewController(
+            isDarkTheme = isDarkTheme,
+            profileImageData = profileImageData,
+            userName = userName,
+            occupation = occupation,
+            profileCardTheme = profileCardTheme,
+        )
+    }
+
+    override fun getSupportedThemes(): List<String> = listOf(
+        "LightPill",
+        "DarkPill",
+        "LightDiamond",
+        "DarkDiamond",
+        "LightFlower",
+        "DarkFlower",
+    )
+
+    companion object {
+        @OptIn(ExperimentalObjCName::class)
+        @ObjCName("shared")
+        val shared = IOSProfileCardBridge()
+    }
+}
+
+/**
+ * iOS向けのProfileCardBridgeインスタンス作成
+ */
+actual fun createProfileCardBridge(): ProfileCardBridgeInterface = IOSProfileCardBridge()
+
+/**
+ * 文字列をProfileCardThemeに変換
+ */
+private fun String.toProfileCardTheme(): ProfileCardTheme {
+    return when (this) {
+        "LightPill" -> ProfileCardTheme.LightPill
+        "DarkPill" -> ProfileCardTheme.DarkPill
+        "LightDiamond" -> ProfileCardTheme.LightDiamond
+        "DarkDiamond" -> ProfileCardTheme.DarkDiamond
+        "LightFlower" -> ProfileCardTheme.LightFlower
+        "DarkFlower" -> ProfileCardTheme.DarkFlower
+        else -> ProfileCardTheme.LightPill // デフォルト
+    }
+}


### PR DESCRIPTION
## Issue
- close #133
- This PR is draft.
I have not yet resolved the issue where the crop background turns black.
I appreciate any help you can give me in solving this issue

## Overview (Required)
- ✅ The profile image should be cropped according to the provided shapes: pill, diamond, and flower.
- ❌  For each shape, support both day and night themes.
- ❌ Users should be able to switch between a total of six ProfileCard variations (three shapes × two themes).

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img width="200" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-04 at 17 54 27" src="https://github.com/user-attachments/assets/6431034c-431f-41cb-ad2c-7c67ad58089e" />



## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
