### PR TITLE
[iOS] Add image caching

### DIFF
--- a/app-ios/Native/Sources/Component/CacheAsyncImage.swift
+++ b/app-ios/Native/Sources/Component/CacheAsyncImage.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+public struct CacheAsyncImage<Content, PlaceHolder>: View where Content: View, PlaceHolder: View {
+
+    private let url: URL?
+    private let scale: CGFloat
+    private let contentImage: (Image) -> Content
+    private let placeholder: () -> PlaceHolder
+
+    public init(
+        url: URL?,
+        scale: CGFloat = 1.0,
+        contentImage: @escaping (Image) -> Content,
+        placeholder: @escaping () -> PlaceHolder
+    ) {
+        self.url = url
+        self.scale = scale
+        self.contentImage = contentImage
+        self.placeholder = placeholder
+    }
+
+    public var body: some View {
+        if let cachedImage = ImageCache[url] {
+            contentImage(cachedImage)
+        } else {
+            AsyncImage(
+                url: url,
+                scale: scale,
+                content: { image in
+                    cacheAndRender(image: image)
+                },
+                placeholder: placeholder
+            )
+        }
+    }
+}
+
+extension CacheAsyncImage {
+    fileprivate func cacheAndRender(image: Image) -> some View {
+        ImageCache[url] = image
+        return contentImage(image)
+    }
+}
+
+private actor ImageCache {
+    static private var cache: [URL: Image] = [:]
+
+    static subscript(url: URL?) -> Image? {
+        get {
+            guard let url else { return nil }
+            return Self.cache[url]
+        }
+        set {
+            guard let url else { return }
+            Self.cache[url] = newValue
+        }
+    }
+}
+
+#Preview {
+    CacheAsyncImage(
+        url: URL(string: "https://avatars.githubusercontent.com/u/10727543?s=48&v=4")!,
+        scale: 1.0
+    ) { image in
+        image.resizable()
+            .frame(width: 24, height: 24)
+    } placeholder: {
+        Color.gray
+            .frame(width: 24, height: 24)
+            .cornerRadius(12)
+    }
+
+}

--- a/app-ios/Native/Sources/Component/CircularUserIcon.swift
+++ b/app-ios/Native/Sources/Component/CircularUserIcon.swift
@@ -12,7 +12,7 @@ public struct CircularUserIcon: View {
 
     public var body: some View {
         if let imageUrl, let url = URL(string: imageUrl) {
-            AsyncImage(url: url) { image in
+            CacheAsyncImage(url: url) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)

--- a/app-ios/Native/Sources/Feature/Contributor/Components/ContributorListItem.swift
+++ b/app-ios/Native/Sources/Feature/Contributor/Components/ContributorListItem.swift
@@ -1,3 +1,4 @@
+import Component
 import Model
 import SwiftUI
 import Theme
@@ -7,7 +8,7 @@ struct ContributorListItem: View {
 
     var body: some View {
         HStack(spacing: 16) {
-            AsyncImage(url: contributor.iconUrl) { image in
+            CacheAsyncImage(url: contributor.iconUrl) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)

--- a/app-ios/Native/Sources/Feature/Sponsor/Components/SponsorCard.swift
+++ b/app-ios/Native/Sources/Feature/Sponsor/Components/SponsorCard.swift
@@ -1,3 +1,4 @@
+import Component
 import Model
 import SwiftUI
 import Theme
@@ -22,7 +23,7 @@ struct SponsorCard: View {
     }
 
     var body: some View {
-        AsyncImage(url: sponsor.logoUrl) { image in
+        CacheAsyncImage(url: sponsor.logoUrl) { image in
             image
                 .resizable()
                 .aspectRatio(contentMode: .fit)

--- a/app-ios/Native/Sources/Feature/Staff/Components/StaffLabel.swift
+++ b/app-ios/Native/Sources/Feature/Staff/Components/StaffLabel.swift
@@ -1,3 +1,4 @@
+import Component
 import Model
 import SwiftUI
 import Theme
@@ -8,7 +9,7 @@ struct StaffLabel: View {
     var body: some View {
         HStack(spacing: 12) {
             // Avatar with circular shape and border
-            AsyncImage(url: staff.iconUrl) { image in
+            CacheAsyncImage(url: staff.iconUrl) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- This PR adds image caching to improve the UX
- The original `CacheAsyncImage` is from the DroidKaigi 2023 app
  - https://github.com/DroidKaigi/conference-app-2023/blob/main/app-ios/Modules/Sources/Component/CacheAsyncImage.swift

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
