### PR TITLE
Fix: TimatableDetailFAB - bookmark

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailFloatingMenu.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailFloatingMenu.kt
@@ -91,7 +91,7 @@ private fun TimetableItemDetailFloatingActionButtonMenu(
     modifier: Modifier = Modifier,
 ) {
     var height by remember { mutableIntStateOf(0) }
-    var childMenuIsBookmarked by remember { mutableStateOf(isBookmarked) } // local copy to update after transition
+    var childMenuIsBookmarked by remember(isBookmarked) { mutableStateOf(isBookmarked) } // local copy to update after transition
     val latestIsBookmarked by rememberUpdatedState(isBookmarked) // to ensure the latest value is used in recomposition
 
     // Recompose child menu items only after the view size has settled.


### PR DESCRIPTION
## Issue
- close #311 

## Overview (Required)
- I fixed the bookmark display of the FAB on the timetable details screen. This was an issue that only occurred in landscape orientation.
I'm detecting when the value changes by specifying it as the key for remember.

## Links
- [FAB menu bookmark state not synced between Timetable and TimetableItemDetail in landscape mode](https://github.com/DroidKaigi/conference-app-2025/issues/311)

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/6851af48-2be1-42f6-9669-6b817cf1e97b" width="300" /> | <video src="https://github.com/user-attachments/assets/ca4406b5-a29c-496a-a07b-60be7b4ba507" width="300" />
