### PR TITLE
Add maxLines & overflow to profile front card text

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
@@ -51,12 +51,14 @@ fun ProfileCardUser(
             style = MaterialTheme.typography.bodyMedium,
             color = if (isDarkTheme) Color.White else Color.Black,
             fontFamily = robotoRegularFontFamily(),
+            maxLines = 1,
         )
         Text(
             text = userName,
             style = MaterialTheme.typography.headlineSmall,
             color = if (isDarkTheme) Color.White else Color.Black,
             fontFamily = changoFontFamily(),
+            maxLines = 1,
         )
     }
 }

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/ProfileCardUser.kt
@@ -52,6 +52,7 @@ fun ProfileCardUser(
             color = if (isDarkTheme) Color.White else Color.Black,
             fontFamily = robotoRegularFontFamily(),
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
         Text(
             text = userName,
@@ -59,6 +60,7 @@ fun ProfileCardUser(
             color = if (isDarkTheme) Color.White else Color.Black,
             fontFamily = changoFontFamily(),
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2025/issues/454

## Overview (Required)
- Added maxLines to profile front card text.
- Added TextOverflow.Ellipsis to profile front card text.

The issue only mentioned adding maxLines, but I think we should also indicate when text is too long. Therefore, I added TextOverflow.Ellipsis as well. If that is not necessary, I will remove this.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img width="1080" height="2400" alt="before" src="https://github.com/user-attachments/assets/f8ddbcee-a023-47b6-b416-dbdaa5784a7a" /> | <img width="1080" height="2400" alt="after" src="https://github.com/user-attachments/assets/e35f8cc9-af50-4fa2-a172-5be72ba2cab3" />

## Movie (Optional)

Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
