### PR TITLE
:wrench: The settings screen has been modified to display in a two-pane layout.

### DIFF
--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SettingsNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SettingsNavEntry.kt
@@ -4,6 +4,7 @@ import androidx.navigation3.runtime.EntryProviderBuilder
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
 import io.github.droidkaigi.confsched.AppGraph
+import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyDetailPaneMetaData
 import io.github.droidkaigi.confsched.navkey.SettingsNavKey
 import io.github.droidkaigi.confsched.settings.SettingsScreenRoot
 import io.github.droidkaigi.confsched.settings.rememberSettingsScreenContextRetained
@@ -12,7 +13,9 @@ context(appGraph: AppGraph)
 fun EntryProviderBuilder<NavKey>.settingsEntry(
     onBackClick: () -> Unit,
 ) {
-    entry<SettingsNavKey> {
+    entry<SettingsNavKey>(
+        metadata = listDetailSceneStrategyDetailPaneMetaData(),
+    ) {
         with(rememberSettingsScreenContextRetained()) {
             SettingsScreenRoot(
                 onBackClick = onBackClick,


### PR DESCRIPTION
## Issue
- close #532

## Overview (Required)
- We have modified the settings screen to display in TwoPane mode when set to landscape orientation.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/acc8a80f-052c-4d5d-984b-fe44c17b3a41" width="300" > | <video src="https://github.com/user-attachments/assets/d6cd1b16-5d93-43e1-9711-48982d89f2da" width="300" >