### PR TITLE
feat: Handle back press to return to the main TimeTable tab

### DIFF
--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -65,7 +65,7 @@ actual fun KaigiAppUi() {
                 MainScreenTab.Profile -> ProfileNavKey
             }
             backStack.clear()
-            backStack.add(navKey)
+            backStack.addAll(listOf(TimetableNavKey, navKey).distinct())
         },
         hazeState = hazeState,
     ) {

--- a/app-shared/src/androidMain/kotlin/io/github/droidkaigi/confsched/navigation/Nav3Interop.android.kt
+++ b/app-shared/src/androidMain/kotlin/io/github/droidkaigi/confsched/navigation/Nav3Interop.android.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.navigation
 
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
 import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.runtime.Composable
@@ -31,7 +32,7 @@ actual fun listDetailSceneStrategyDetailPaneMetaData(): Map<String, Any> {
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 actual fun sceneStrategy(): SceneStrategy<NavKey> {
-    return rememberListDetailSceneStrategy()
+    return rememberListDetailSceneStrategy(BackNavigationBehavior.PopLatest)
 }
 
 @Composable

--- a/app-shared/src/androidMain/kotlin/io/github/droidkaigi/confsched/navigation/Nav3Interop.android.kt
+++ b/app-shared/src/androidMain/kotlin/io/github/droidkaigi/confsched/navigation/Nav3Interop.android.kt
@@ -32,6 +32,8 @@ actual fun listDetailSceneStrategyDetailPaneMetaData(): Map<String, Any> {
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 actual fun sceneStrategy(): SceneStrategy<NavKey> {
+    // To pop the continuous list pane's backstack one by one using PopLatest.
+    // https://github.com/DroidKaigi/conference-app-2025/pull/539
     return rememberListDetailSceneStrategy(BackNavigationBehavior.PopLatest)
 }
 


### PR DESCRIPTION
## Issue
- close #490

## Overview

As per the issue and as implemented in last year's conference app, when the back button or back gesture is used while on a tab other than the TimeTable tab, the app now navigates back to the TimeTable screen. 

### about `BackNavigationBehavior.PopLatest`

Furthermore, by using `BackNavigationBehavior.PopLatest`, I have implemented a more intuitive back navigation experience. 


This change fixes an issue where the app would close on foldable devices when the back button was pressed from the About screen or Search screen.
(The issue with the About Screen was introduced with this change, but the issue with the Search Screen has been there from the beginning.)


The issue occurred because the default `BackNavigationBehavior` in `adaptive-navigation3` removes the previous all ListPane screen when a user presses the back button on a continuous ListPane screen on foldable devices. I have reported this behavior in the [issue tracker](https://issuetracker.google.com/issues/442618065).


For more details on `BackNavigationBehavior`, see the official documentation on [Build a list\-detail layout  \|  Jetpack Compose  \|  Android Developers](https://developer.android.com/develop/ui/compose/layouts/adaptive/list-detail). Although the documentation includes a warning about PopLatest, it doesn't apply to this app because we replace the back stack when navigating between detail screens instead of adding to it.

I confirmed that there are no operational issues with the desktop app.


## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/584b1634-6156-4230-b911-1d31f23101d9" width="300" >|<video src="https://github.com/user-attachments/assets/06c9a46d-f661-4a9e-9f37-689b8005c765" width="300" > 








