### PR TITLE
Make more flexible image picker source

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
@@ -452,7 +452,7 @@ private fun ImagePicker(
     onClear: () -> Unit,
 ) {
     val launcher = rememberFilePickerLauncher(
-        type = FileKitType.Image,
+        type = FileKitType.File(extensions = listOf("png", "jpg", "jpeg", "gif", "bmp")),
     ) { file ->
         file?.let { file ->
             onImageChange(file)


### PR DESCRIPTION
## Issue
- close #485

## Overview (Required)
- Change the picker for select image to file picker from image picker in order to be able to use more flexible data source
    - Restrict to files which has image extensions

## Movie (Optional)
| Before | After |
| :--: | :--: |
| <video src="https://github.com/user-attachments/assets/5ba66e56-4bef-4d28-8c7c-d153b07a271d"> | <video src="https://github.com/user-attachments/assets/04567f70-ecef-4618-875f-0d11b886f753"> |
