### PR TITLE
Replace KaigiTheme with KaigiPreviewContainer in preview functions

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ColorSample.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ColorSample.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -120,9 +120,7 @@ private fun ColorBox(color: Color) {
 @Preview
 @Composable
 private fun ColorPreview_Dark() {
-    KaigiTheme {
-        Surface {
-            ColorBoxes()
-        }
+    KaigiPreviewContainer {
+        ColorBoxes()
     }
 }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/components/AboutLinkIcon.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/components/AboutLinkIcon.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.about.AboutRes
 import io.github.droidkaigi.confsched.about.icon_youtube
-import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -60,14 +60,12 @@ fun AboutLinkIcon(
 @Preview
 @Composable
 private fun AboutLinkIconPreview() {
-    KaigiTheme {
-        Surface {
-            AboutLinkIcon(
-                testTag = "testTag",
-                painter = painterResource(AboutRes.drawable.icon_youtube),
-                contentDescription = "YouTube",
-                onClick = {},
-            )
-        }
+    KaigiPreviewContainer {
+        AboutLinkIcon(
+            testTag = "testTag",
+            painter = painterResource(AboutRes.drawable.icon_youtube),
+            contentDescription = "YouTube",
+            onClick = {},
+        )
     }
 }


### PR DESCRIPTION
## Issue
- close #410 

## Overview (Required)
- In the Preview function, there were places where KaigiPreviewContainer and KaigiTheme were used, so I unified it to use KaigiPreviewContainer.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
