### PR TITLE
fix: sponsor card pressed style

### DIFF
--- a/app-ios/Native/Sources/Feature/Sponsor/Components/SponsorCard.swift
+++ b/app-ios/Native/Sources/Feature/Sponsor/Components/SponsorCard.swift
@@ -81,7 +81,7 @@ struct SponsorSection: View {
                             )
                         }
                     )
-                    .buttonStyle(PlainButtonStyle())
+                    .sponsorCardStyle()
                 }
             }
             .padding(.horizontal, 16)

--- a/app-ios/Native/Sources/Feature/Sponsor/Components/SponsorCardStyle.swift
+++ b/app-ios/Native/Sources/Feature/Sponsor/Components/SponsorCardStyle.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+// Sponsor card style
+struct SponsorCardStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        ZStack {
+            configuration.label
+            if configuration.isPressed {
+                Color.black
+                    .opacity(0.2)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+    }
+}
+
+extension View {
+    func sponsorCardStyle() -> some View {
+        buttonStyle(SponsorCardStyle())
+    }
+}


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- The pressed style of the sponsor card currently feels a bit unnatural, so I’m updating it by applying a custom button style

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/f7c7606a-de87-43e2-ab0b-ced6bc085293" width="300" > | <video src="https://github.com/user-attachments/assets/51aab9c5-c54f-4578-8175-a14093fcc0dc" width="300" >
