### PR TITLE
Set a placeholder in the input field of the search screen

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchTopBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchTopBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
@@ -24,6 +25,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
+import io.github.droidkaigi.confsched.sessions.SessionsRes
+import io.github.droidkaigi.confsched.sessions.search_sessions
+import org.jetbrains.compose.resources.stringResource
 
 const val SearchTopBarTextFieldTestTag = "SearchTopBarTextFieldTestTag"
 
@@ -44,6 +48,12 @@ fun SearchTopBar(
                 value = searchQuery,
                 onValueChange = onQueryChange,
                 singleLine = true,
+                placeholder = {
+                    Text(
+                        text = stringResource(SessionsRes.string.search_sessions),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                },
                 keyboardOptions = KeyboardOptions(
                     imeAction = ImeAction.Search,
                 ),


### PR DESCRIPTION
## Issue
- close #505 

## Overview
- Set a placeholder string in the input field of search screen so that user can get the hints what to search

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/b03ecd5a-7203-447e-8ca0-bef4225b751f" width="300" /> | <img src="https://github.com/user-attachments/assets/4b6fa7e4-1ba3-4597-bf28-819a3e11a043" width="300" />
<img src="https://github.com/user-attachments/assets/64a6d2e4-cfd2-4549-8e3e-58485b6c0a83" width="300" /> | <img src="https://github.com/user-attachments/assets/3c62c6d2-9972-450b-b9bc-18ba9de2b7db" width="300" />
