### PR TITLE
Remove the unused “status” item from the SponsorsResponse

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sponsors/response/SponsorsResponse.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sponsors/response/SponsorsResponse.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class SponsorsResponse(
-    // val status: String,
     @SerialName("sponsor")
     val sponsors: List<SponsorResponse> = emptyList(),
 )


### PR DESCRIPTION
## Issue
- close #https://github.com/DroidKaigi/conference-app-2025/issues/549

## Overview (Required)
- I deleted the status property from SponsorsResponse because it wasn't being used.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
