### PR TITLE
:wrench: We have adjusted the link color on AboutScreen to match the design.

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
@@ -41,7 +41,7 @@ fun ClickableLinkText(
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,
     hasUnderLine: Boolean = true,
-    underLineColor: Color = LightBlue,
+    underLineAndLinkTextColor: Color = LightBlue,
     onOverflow: (Boolean) -> Unit = {},
 ) {
     val findResults = findResults(
@@ -63,7 +63,7 @@ fun ClickableLinkText(
         text = buildClickableAnnotatedString(
             content = content,
             hasUnderLine = hasUnderLine,
-            underLineColor = underLineColor,
+            underLineColor = underLineAndLinkTextColor,
             findUrlResults = findResults,
             onLinkClick = onLinkClick,
         ),
@@ -97,7 +97,7 @@ private fun buildClickableAnnotatedString(
     return buildAnnotatedString {
         pushStyle(
             style = SpanStyle(
-                color = MaterialTheme.colorScheme.inverseSurface,
+                color = MaterialTheme.colorScheme.onSurface,
             ),
         )
 

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/components/AboutDroidKaigiSummaryCard.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/components/AboutDroidKaigiSummaryCard.kt
@@ -96,7 +96,7 @@ private fun AboutDroidKaigiSummaryCardRow(
             content = content,
             onLinkClick = onLinkClick,
             hasUnderLine = false,
-            underLineColor = MaterialTheme.colorScheme.surfaceTint,
+            underLineAndLinkTextColor = MaterialTheme.colorScheme.primary,
             regex = stringResource(AboutRes.string.place_link).toRegex(),
         )
     }


### PR DESCRIPTION
## Issue
- close #579

## Overview (Required)
- I also fixed the colors other than the links, as they differed from the design.

## Links
- https://www.figma.com/design/1YjyMBNVLEGcHP4W7UNzDE/DroidKaigi-2025-App-UI?node-id=54985-75932&t=LKmQ7KyuITaWg7Zq-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/7e598772-be5c-44e8-bba0-1a840b0da332" width="300" /> | <img src="https://github.com/user-attachments/assets/76450b2e-3475-4459-968c-39f23e1e01a5" width="300" />