### PR TITLE
:wrench: The issue where TimetableTimeSlot would sometimes be clipped in a circular manner has been addressed.

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableList.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableList.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -23,9 +24,9 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiWindowSizeClassConstants
@@ -94,7 +95,7 @@ fun TimetableList(
                         endTimeText = timeSlot.endTimeString,
                         modifier = Modifier
                             .onSizeChanged { timetableTimeSlotHeight = it.height }
-                            .graphicsLayer { translationY = timetableTimeSlotOffsetY.toFloat() },
+                            .offset { IntOffset(0, timetableTimeSlotOffsetY) },
                     )
                     Column(
                         verticalArrangement = Arrangement.spacedBy(12.dp),


### PR DESCRIPTION
## Issue
- close #584

## Overview (Required)

This issue occurred when the following PR was merged.
It is clear from the video embedded in the PR and the VRT difference images that the problem originated from this PR.
#525

When using

```kotlin
.graphicsLayer { translationY = timetableTimeSlotOffsetY.toFloat() }
```

to move the `TimetableTimeSlot`, the slot is rendered into its own off-screen layer.
That layer is clipped to its outline (mask) when composed back into the parent.

Depending on the scroll position, this outline sometimes became a **rounded shape**, so the time text (and even any debug rectangles drawn with `drawWithContent`) appeared to be **cut off in a circular way**.
Once the slot moved past that region, the clipping outline became rectangular again, so the slot switched from *rounded → square*.

### Visual explanation (simplified)

```
┌────────── Screen ──────────┐
│ [Item A area]              │
│  ├─ Left: TimeSlot layer   │
│  └─ Right: Rounded card of │
│          next item (B)     │
│                            │
│ As TimeSlot is translated  │
│ downward, its layer enters │
│ the rounded outline region │
│ of the next card.          │
│                            │
│ → While intersecting:      │
│   TimeSlot is clipped by   │
│   that rounded outline.    │
│ → After leaving:           │
│   back to rectangular clip │
└────────────────────────────┘
```


### Verification

* With `drawWithContent { drawContent(); drawRect(...) }`, the rectangle itself was clipped → proves it is **self layer clipping**, not a sibling overlay.
* Forcing

  ```kotlin
  graphicsLayer { shape = RectangleShape; clip = true }
  ```

  resulted in **square clipping only**.
* Setting

  ```kotlin
  graphicsLayer { clip = false }
  ```

  removed the clipping entirely.


### Fix

Use layout offset instead of a graphics layer:

```kotlin
Modifier.offset { IntOffset(0, timetableTimeSlotOffsetY) }
```

This moves the element without creating an extra layer, so no unintended clipping occurs.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/4cb48d66-5a8f-4ff7-b728-ae06a7f2404c" width="300" > | <video src="https://github.com/user-attachments/assets/78b92bad-bd39-40b4-90d9-bec82369d03c" width="300" >

The following verification video used drawWithContent.

 ```kotlin
                    TimetableTimeSlot(
                        startTimeText = timeSlot.startTimeString,
                        endTimeText = timeSlot.endTimeString,
                        modifier = Modifier
                            .onSizeChanged { timetableTimeSlotHeight = it.height }
                            .offset { IntOffset(0, timetableTimeSlotOffsetY) }
                            .drawWithContent {
                                drawContent()
                                drawRect(Color.Cyan.copy(alpha = 0.35f))
                            },
                    )
 ```

Before (Verification) | After (Verification)
:--: | :--:
<video src="https://github.com/user-attachments/assets/bfd8f561-6383-4af3-903d-2f6d351e51d6" width="300" > | <video src="https://github.com/user-attachments/assets/b06c5f8a-df4b-450e-90cf-a7927de65619" width="300" >