### PR TITLE
[iOS] Fix text alignment on timetable card

### DIFF
--- a/app-ios/Native/Sources/Feature/Home/Components/TimetableGridCard.swift
+++ b/app-ios/Native/Sources/Feature/Home/Components/TimetableGridCard.swift
@@ -26,6 +26,7 @@ struct TimetableGridCard: View {
                     .lineLimit(2)
 
                 Spacer()
+                    .frame(maxWidth: .infinity)
 
                 if !timetableItem.speakers.isEmpty {
                     HStack {
@@ -42,7 +43,6 @@ struct TimetableGridCard: View {
                 }
             }
             .padding(8)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(timetableItem.room.color.opacity(0.1))
             .overlay(
                 RoundedRectangle(cornerRadius: 8)


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- This PR fixes text alignment on the timetable card for sessions with no speakers

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/e0d56d47-f0fa-4f17-813f-b1f96d61954a" width="300" /> | <img src="https://github.com/user-attachments/assets/8bf30746-7b0f-43e6-b842-3c6748e3a188" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
