### PR TITLE
[iOS] Add extra bottom padding on timetable details

### DIFF
--- a/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
+++ b/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
@@ -35,6 +35,8 @@ public struct TimetableDetailScreen: View {
                         .padding(.horizontal, 16)
                     targetAudience
                         .padding(16)
+
+                    Spacer().frame(height: 56)  // FAB space
                 }
 
                 fabMenu


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- This PR adds extra bottom padding to prevent the FAB overlap on the timetable details screen

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/034b3da1-4f6f-4d2e-8cfd-033b68e8fea0" width="300" /> | <img src="https://github.com/user-attachments/assets/431acafa-b0fe-4349-9698-513c52ec1aca" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
