### PR TITLE
Change: Set a max height for the dropdown menus in the search screen

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchFilterRow.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/SearchFilterRow.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
@@ -175,6 +176,7 @@ private fun <T> FilterDropdown(
         )
 
         DropdownMenu(
+            modifier = Modifier.heightIn(max = 300.dp),
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {


### PR DESCRIPTION
## Issue
- close #451

## Overview (Required)
- Set a max height for the dropdown menus in the search screen.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a1d8c413-74b7-4303-ba07-f671f2510d47" width="300" /> | <img src="https://github.com/user-attachments/assets/8664d857-6335-41c8-9020-4c0c02e133c4" width="300" />
<img src="https://github.com/user-attachments/assets/9f0d8b6f-173f-412a-95f4-bb54e75df82a" width="300" /> | <img src="https://github.com/user-attachments/assets/d019e329-a106-4325-9adb-487b2580a33e" width="300" />

## Movie (Optional)
<video src="https://github.com/user-attachments/assets/3ce01aea-487b-492e-8d45-765ed8259ac9" width="300" >