### PR TITLE
:recycle: Modified to use mouseNavigationSupportForDesktop instead of bindMouseBackForward.

### DIFF
--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -9,8 +9,7 @@ import dev.chrisbanes.haze.rememberHazeState
 import io.github.droidkaigi.confsched.component.KaigiNavigationScaffold
 import io.github.droidkaigi.confsched.component.MainScreenTab
 import io.github.droidkaigi.confsched.component.NavDisplayWithSharedAxisX
-import io.github.droidkaigi.confsched.component.rememberOneStepForwardControllerForDesktop
-import io.github.droidkaigi.confsched.droidkaigiui.extension.bindMouseBackForward
+import io.github.droidkaigi.confsched.component.mouseNavigationSupportForDesktop
 import io.github.droidkaigi.confsched.model.about.AboutItem
 import io.github.droidkaigi.confsched.model.core.Lang
 import io.github.droidkaigi.confsched.model.core.defaultLang
@@ -43,7 +42,6 @@ import io.github.droidkaigi.confsched.navkey.TimetableNavKey
 context(appGraph: AppGraph)
 actual fun KaigiAppUi() {
     val backStack = rememberNavBackStack(TimetableNavKey)
-    val doForward = rememberOneStepForwardControllerForDesktop(backStack)
     val externalNavController = rememberExternalNavController()
     val hazeState = rememberHazeState()
 
@@ -175,18 +173,8 @@ actual fun KaigiAppUi() {
             modifier = Modifier
                 .fillMaxSize()
                 .hazeSource(hazeState)
-                .bindMouseBackForward(
-                    onBackPressed = {
-                        if (backStack.size > 1) {
-                            backStack.removeLastOrNull()
-                        } else {
-                            backStack.clear()
-                            backStack.add(TimetableNavKey)
-                        }
-                    },
-                    onForwardPressed = {
-                        doForward()
-                    },
+                .mouseNavigationSupportForDesktop(
+                    backStack = backStack,
                 ),
         )
     }

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/component/MouseNavigationSupportForDesktop.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/component/MouseNavigationSupportForDesktop.kt
@@ -1,0 +1,42 @@
+package io.github.droidkaigi.confsched.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isBackPressed
+import androidx.compose.ui.input.pointer.isForwardPressed
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.navigation3.runtime.NavKey
+import io.github.droidkaigi.confsched.navkey.TimetableNavKey
+
+@Composable
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun Modifier.mouseNavigationSupportForDesktop(
+    backStack: SnapshotStateList<NavKey>,
+): Modifier {
+    val doForward = rememberOneStepForwardControllerForDesktop(backStack)
+
+    return this.onPointerEvent(
+        eventType = PointerEventType.Press,
+        pass = PointerEventPass.Initial,
+    ) { e ->
+        when {
+            e.buttons.isBackPressed -> {
+                if (backStack.size > 1) {
+                    backStack.removeLastOrNull()
+                } else {
+                    backStack.clear()
+                    backStack.add(TimetableNavKey)
+                }
+                e.changes.forEach { it.consume() }
+            }
+            e.buttons.isForwardPressed -> {
+                doForward()
+                e.changes.forEach { it.consume() }
+            }
+        }
+    }
+}

--- a/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.android.kt
+++ b/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.android.kt
@@ -10,12 +10,6 @@ actual fun Modifier.enableMouseDragScroll(
 ): Modifier = this // NOOP
 
 @Composable
-actual fun Modifier.bindMouseBackForward(
-    onBackPressed: () -> Unit,
-    onForwardPressed: () -> Unit,
-): Modifier = this // NOOP
-
-@Composable
 actual fun Modifier.enableMouseWheelZoomForDesktop(
     multiplyVerticalScaleBy: (Float) -> Unit,
     zoomStep: Float,

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.kt
@@ -10,12 +10,6 @@ expect fun Modifier.enableMouseDragScroll(
 ): Modifier
 
 @Composable
-expect fun Modifier.bindMouseBackForward(
-    onBackPressed: () -> Unit,
-    onForwardPressed: () -> Unit,
-): Modifier
-
-@Composable
 expect fun Modifier.enableMouseWheelZoomForDesktop(
     multiplyVerticalScaleBy: (Float) -> Unit,
     zoomStep: Float = 1.05f,

--- a/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.ios.kt
+++ b/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.ios.kt
@@ -10,12 +10,6 @@ actual fun Modifier.enableMouseDragScroll(
 ): Modifier = this // NOOP
 
 @Composable
-actual fun Modifier.bindMouseBackForward(
-    onBackPressed: () -> Unit,
-    onForwardPressed: () -> Unit,
-): Modifier = this // NOOP
-
-@Composable
 actual fun Modifier.enableMouseWheelZoomForDesktop(
     multiplyVerticalScaleBy: (Float) -> Unit,
     zoomStep: Float,

--- a/core/droidkaigiui/src/jvmMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.jvm.kt
+++ b/core/droidkaigiui/src/jvmMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/extension/ModifierExtensions.jvm.kt
@@ -143,27 +143,6 @@ actual fun Modifier.enableMouseDragScroll(
         }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
-@Composable
-actual fun Modifier.bindMouseBackForward(
-    onBackPressed: () -> Unit,
-    onForwardPressed: () -> Unit,
-): Modifier = this.onPointerEvent(
-    eventType = PointerEventType.Press,
-    pass = PointerEventPass.Initial,
-) { e ->
-    when {
-        e.buttons.isBackPressed -> {
-            onBackPressed()
-            e.changes.forEach { it.consume() }
-        }
-        e.buttons.isForwardPressed -> {
-            onForwardPressed()
-            e.changes.forEach { it.consume() }
-        }
-    }
-}
-
 private const val VerticalWheelDeltaThreshold = 0.01f
 
 private enum class ZoomDirection { ZoomIn, ZoomOut }


### PR DESCRIPTION
## Issue
- close #587

## Overview (Required)
- Unnecessary expect/actual method definitions have been removed.