### PR TITLE
:recycle: Implement functionality to distinguish bookmark states in the timetable's grid layout mode. 

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/RoomTheme.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/RoomTheme.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 sealed interface RoomTheme {
     val primaryColor: Color
     val containerColor: Color get() = primaryColor.copy(alpha = 0.1f)
+    val containerHighlightColor: Color get() = primaryColor.copy(alpha = 0.7f)
     val dimColor: Color
 
     data object Jellyfish : RoomTheme {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/grid/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/grid/TimetableGrid.kt
@@ -132,6 +132,7 @@ fun TimetableGrid(
                     ) {
                         TimetableGridItem(
                             timetableItem = timetableItem,
+                            isBookmarked = timetable.bookmarks.contains(timetableItem.id),
                             onTimetableItemClick = { onTimetableItemClick(it.id) },
                             scaleState = timetableState.scaleState,
                         )


### PR DESCRIPTION
## Issue
- close #582

## Overview (Required)
- The new design for TimetableGridItem has been applied.

## Links
- https://www.figma.com/design/1YjyMBNVLEGcHP4W7UNzDE/DroidKaigi-2025-App-UI?node-id=54888-47117&t=wfpvgzpRqBKy8TxY-4

## Movie (Optional)
Android | iOS | JVM
:--: | :--: | :--:
<video src="https://github.com/user-attachments/assets/7e8c57dc-2b52-4cb3-8105-714d78838f49" width="300" > | <video src="https://github.com/user-attachments/assets/5a51e038-c340-4541-bead-33e8908ddcbb" width="300" > | <video src="https://github.com/user-attachments/assets/f7008520-b8d6-44be-87d5-4b85634ebae4" width="300" >