### PR TITLE
[iOS] Apply new design to TimetableGridCard and some design adjustment

### DIFF
--- a/app-ios/Native/Package.swift
+++ b/app-ios/Native/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
                 .target(name: "Extension"),
                 .target(name: "Theme"),
                 .product(name: "Model", package: "Core"),
+                .product(name: "Presentation", package: "Core"),
             ]
         ),
         .testTarget(

--- a/app-ios/Native/Sources/Component/CircularUserIcon.swift
+++ b/app-ios/Native/Sources/Component/CircularUserIcon.swift
@@ -16,22 +16,30 @@ public struct CircularUserIcon: View {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .overlay {
-                        Circle()
-                            .stroke(AssetColors.outline.swiftUIColor)
-                    }
             } placeholder: {
-                Image(systemName: "person.circle.fill")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .foregroundStyle(AssetColors.outline.swiftUIColor)
+                // NOTE: If you only use ProgressView, it cannot determine the correct size.
+                ZStack {
+                    Circle()
+                        .foregroundStyle(AssetColors.surface.swiftUIColor)
+                    ProgressView()
+                }
             }
+            .background(AssetColors.surface.swiftUIColor)
             .clipShape(Circle())
+            .overlay {
+                Circle()
+                    .stroke(AssetColors.outline.swiftUIColor)
+            }
         } else {
             Image(systemName: "person.circle.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fill)
-                .foregroundStyle(AssetColors.outline.swiftUIColor)
+                .foregroundStyle(AssetColors.onSurface.swiftUIColor)
+                .background(AssetColors.surface.swiftUIColor)
+                .overlay {
+                    Circle()
+                        .stroke(AssetColors.outline.swiftUIColor)
+                }
         }
     }
 }

--- a/app-ios/Native/Sources/Component/Resources/Localizable.xcstrings
+++ b/app-ios/Native/Sources/Component/Resources/Localizable.xcstrings
@@ -1,6 +1,16 @@
 {
   "sourceLanguage" : "ja",
   "strings" : {
+    "%@ ~ %@" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ ~ %2$@"
+          }
+        }
+      }
+    },
     "|" : {
 
     },

--- a/app-ios/Native/Sources/Component/TimetableCard.swift
+++ b/app-ios/Native/Sources/Component/TimetableCard.swift
@@ -73,11 +73,7 @@ public struct TimetableCard: View {
         } label: {
             (isFavorite ? AssetImages.icFavFill.swiftUIImage : AssetImages.icFav.swiftUIImage)
                 .resizable()
-                .foregroundStyle(
-                    isFavorite
-                        ? AssetColors.primaryFixed.swiftUIColor
-                        : AssetColors.onSurfaceVariant.swiftUIColor
-                )
+                .foregroundStyle(timetableItem.room.color)
                 .frame(width: 24, height: 24)
                 .padding(.leading, 16)
                 .padding(.trailing, 12)

--- a/app-ios/Native/Sources/Component/TimetableGridCard.swift
+++ b/app-ios/Native/Sources/Component/TimetableGridCard.swift
@@ -1,27 +1,39 @@
-import Component
 import Extension
 import Model
 import Presentation
 import SwiftUI
 import Theme
 
-struct TimetableGridCard: View {
+public struct TimetableGridCard: View {
     let timetableItem: any TimetableItem
+    let isFavorite: Bool
     let onTap: (any TimetableItem) -> Void
 
-    var body: some View {
+    public init(timetableItem: any TimetableItem, isFavorite: Bool, onTap: @escaping (any TimetableItem) -> Void) {
+        self.timetableItem = timetableItem
+        self.isFavorite = isFavorite
+        self.onTap = onTap
+    }
+
+    public var body: some View {
         Button {
             onTap(timetableItem)
         } label: {
             VStack(alignment: .leading, spacing: 4) {
-                Text("\(timetableItem.startsTimeString) ~ \(timetableItem.endsTimeString)")
-                    .font(Typography.labelLarge)
-                    .foregroundStyle(timetableItem.room.color)
-                    .multilineTextAlignment(.leading)
+                HStack(spacing: 4) {
+                    Image(timetableItem.room.iconName, bundle: .module)
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(width: 12, height: 12)
+                    Text("\(timetableItem.startsTimeString) ~ \(timetableItem.endsTimeString)")
+                        .font(Typography.labelLarge)
+                        .multilineTextAlignment(.leading)
+                }
+                .foregroundStyle(contentForegroundColor)
 
                 Text(timetableItem.title.currentLangTitle)
                     .font(Typography.labelLarge)
-                    .foregroundStyle(timetableItem.room.color)
+                    .foregroundStyle(contentForegroundColor)
                     .multilineTextAlignment(.leading)
                     .lineLimit(2)
 
@@ -35,7 +47,7 @@ struct TimetableGridCard: View {
 
                         Text(timetableItem.speakers.map(\.name).joined(separator: ", "))
                             .font(Typography.bodySmall)
-                            .foregroundStyle(AssetColors.onSurface.swiftUIColor)
+                            .foregroundStyle(speakerForegroundColor)
                             .lineLimit(1)
 
                         Spacer()
@@ -43,7 +55,7 @@ struct TimetableGridCard: View {
                 }
             }
             .padding(8)
-            .background(timetableItem.room.color.opacity(0.1))
+            .background(backgroundColor)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(timetableItem.room.color, lineWidth: 1)
@@ -52,11 +64,24 @@ struct TimetableGridCard: View {
         }
         .buttonStyle(PlainButtonStyle())
     }
+
+    private var contentForegroundColor: Color {
+        isFavorite ? AssetColors.surface.swiftUIColor : timetableItem.room.color
+    }
+
+    private var speakerForegroundColor: Color {
+        isFavorite ? AssetColors.surface.swiftUIColor : AssetColors.onSurface.swiftUIColor
+    }
+
+    private var backgroundColor: Color {
+        timetableItem.room.color.opacity(isFavorite ? 0.7 : 0.1)
+    }
 }
 
 #Preview {
     TimetableGridCard(
         timetableItem: PreviewData.timetableItemSession,
+        isFavorite: false,
         onTap: { _ in }
     )
     .frame(width: 200, height: 100)

--- a/app-ios/Native/Sources/Feature/Contributor/Components/ContributorListItem.swift
+++ b/app-ios/Native/Sources/Feature/Contributor/Components/ContributorListItem.swift
@@ -8,17 +8,8 @@ struct ContributorListItem: View {
 
     var body: some View {
         HStack(spacing: 16) {
-            CacheAsyncImage(url: contributor.iconUrl) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            } placeholder: {
-                Image(systemName: "person.circle.fill")
-                    .resizable()
-                    .foregroundColor(AssetColors.onSurface.swiftUIColor.opacity(0.6))
-            }
-            .frame(width: 56, height: 56)
-            .clipShape(Circle())
+            CircularUserIcon(imageUrl: contributor.iconUrl.absoluteString)
+                .frame(width: 56, height: 56)
 
             Text(contributor.name)
                 .font(.body)

--- a/app-ios/Native/Sources/Feature/Home/Components/TimetableGridView.swift
+++ b/app-ios/Native/Sources/Feature/Home/Components/TimetableGridView.swift
@@ -186,6 +186,7 @@ struct TimetableGridView: View {
 
                 TimetableGridCard(
                     timetableItem: item.timetableItem,
+                    isFavorite: item.isFavorited,
                     onTap: { _ in onItemTap(item) }
                 )
                 .frame(width: width, height: height)

--- a/app-ios/Native/Sources/Feature/Home/Resources/Localizable.xcstrings
+++ b/app-ios/Native/Sources/Feature/Home/Resources/Localizable.xcstrings
@@ -1,16 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "%@ ~ %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ ~ %2$@"
-          }
-        }
-      }
-    },
     "00:00" : {
 
     },

--- a/app-ios/Native/Sources/Feature/Staff/Components/StaffLabel.swift
+++ b/app-ios/Native/Sources/Feature/Staff/Components/StaffLabel.swift
@@ -8,22 +8,8 @@ struct StaffLabel: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            // Avatar with circular shape and border
-            CacheAsyncImage(url: staff.iconUrl) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            } placeholder: {
-                // Placeholder with background color from Figma
-                Circle()
-                    .fill(AssetColors.onSurface.swiftUIColor)
-            }
-            .frame(width: 52, height: 52)
-            .clipShape(Circle())
-            .overlay(
-                Circle()
-                    .stroke(AssetColors.outline.swiftUIColor, lineWidth: 1)
-            )
+            CircularUserIcon(imageUrl: staff.iconUrl.absoluteString)
+                .frame(width: 52, height: 52)
 
             VStack(alignment: .leading, spacing: 0) {
                 Text(staff.name)


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Apply new design to TimetableGridCard  
- Add room icon  
- Adjust CircularUserIcon (apply border to all states and add loading state)  
- Use CircularUserIcon for staff and contributors
- apply favorite button color feature (like android)

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/a053e90b-d9e1-4794-9ffb-3256f7255754" width="300" > | <video src="https://github.com/user-attachments/assets/17a8da3f-b86b-41c9-8fc0-88cd0c69b239" width="300" >


