### PR TITLE
Remove the duplicate TestTag from TimetableItemCard

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableItemCard.kt
@@ -81,7 +81,6 @@ fun TimetableItemCard(
         Row(
             verticalAlignment = Alignment.Top,
             modifier = modifier
-                .testTag(TimetableItemCardTestTag)
                 .semantics {
                     this[TimetableItemCardSemanticsKey] = timetableItem
                 }


### PR DESCRIPTION
## Issue
- close #507 

## Overview
There was duplicate test tag for TimetableItemCard UI item. This PR fixes this by removing the duplicated tag
