### PR TITLE
:sparkles: We implemented a feature that uses the device's sensors to make the card tilt and light up. 

### DIFF
--- a/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.android.kt
+++ b/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.android.kt
@@ -1,0 +1,99 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+internal actual fun getOrientationSensorManager(
+    onOrientationChanged: (Orientation) -> Unit,
+): OrientationSensorManager {
+    val context = LocalContext.current
+    return remember(context, onOrientationChanged) {
+        AndroidOrientationSensorManager(
+            context = context,
+            onOrientationChanged = onOrientationChanged,
+        )
+    }
+}
+
+internal class AndroidOrientationSensorManager(
+    context: Context,
+    override val onOrientationChanged: (Orientation) -> Unit,
+) : OrientationSensorManager,
+    SensorEventListener {
+    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+    private val accelerometerReading = FloatArray(3)
+    private val magnetometerReading = FloatArray(3)
+
+    private val rotationMatrix = FloatArray(9)
+    private val orientationAngles = FloatArray(3)
+
+    override fun start() {
+        sensorManager.registerListener(
+            this,
+            sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
+            SENSOR_DELAY,
+        )
+        sensorManager.registerListener(
+            this,
+            sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD),
+            SENSOR_DELAY,
+        )
+    }
+
+    override fun stop() {
+        sensorManager.unregisterListener(this)
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // Do nothing
+    }
+
+    override fun onSensorChanged(event: SensorEvent) {
+        when (event.sensor.type) {
+            Sensor.TYPE_ACCELEROMETER -> {
+                System.arraycopy(
+                    event.values,
+                    0,
+                    accelerometerReading,
+                    0,
+                    accelerometerReading.size,
+                )
+            }
+
+            Sensor.TYPE_MAGNETIC_FIELD -> {
+                System.arraycopy(event.values, 0, magnetometerReading, 0, magnetometerReading.size)
+            }
+        }
+        updateOrientationAngles()
+
+        onOrientationChanged(
+            Orientation(
+                azimuth = orientationAngles[0],
+                pitch = orientationAngles[1],
+                roll = orientationAngles[2],
+            ),
+        )
+    }
+
+    private fun updateOrientationAngles() {
+        SensorManager.getRotationMatrix(
+            rotationMatrix,
+            null,
+            accelerometerReading,
+            magnetometerReading,
+        )
+        SensorManager.getOrientation(rotationMatrix, orientationAngles)
+    }
+
+    companion object {
+        private const val SENSOR_DELAY: Int = SensorManager.SENSOR_DELAY_UI
+    }
+}

--- a/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.android.kt
+++ b/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.android.kt
@@ -1,0 +1,40 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+actual fun WithDeviceOrientation(
+    content: @Composable (DeviceOrientationScope.() -> Unit),
+) {
+    val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+
+    val scope = remember {
+        DeviceOrientationScopeImpl()
+    }
+    val sensorManager = getOrientationSensorManager {
+        scope.updateOrientation(it)
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                sensorManager.start()
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
+                sensorManager.stop()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    content(scope)
+}

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.kt
@@ -1,0 +1,24 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+
+data class Orientation(
+    val azimuth: Float,
+    val pitch: Float,
+    val roll: Float,
+) {
+    companion object {
+        val Zero = Orientation(0f, 0f, 0f)
+    }
+}
+
+internal interface OrientationSensorManager {
+    val onOrientationChanged: (Orientation) -> Unit
+    fun start()
+    fun stop()
+}
+
+@Composable
+internal expect fun getOrientationSensorManager(
+    onOrientationChanged: (Orientation) -> Unit,
+): OrientationSensorManager

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.kt
@@ -1,0 +1,56 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+interface DeviceOrientationScope {
+    val orientation: Orientation
+}
+
+private class DeviceOrientationScopeImpl : DeviceOrientationScope {
+    override var orientation: Orientation by mutableStateOf(Orientation.Zero)
+        private set
+
+    fun updateOrientation(orientation: Orientation) {
+        this.orientation = orientation
+    }
+}
+
+@Composable
+fun WithDeviceOrientation(
+    content: @Composable (DeviceOrientationScope.() -> Unit),
+) {
+    val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+
+    val scope = remember {
+        DeviceOrientationScopeImpl()
+    }
+    val sensorManager = getOrientationSensorManager {
+        scope.updateOrientation(it)
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                sensorManager.start()
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
+                sensorManager.stop()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    content(scope)
+}

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.kt
@@ -1,21 +1,11 @@
 package io.github.droidkaigi.confsched.droidkaigiui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.compose.LocalLifecycleOwner
 
-interface DeviceOrientationScope {
-    val orientation: Orientation
-}
-
-private class DeviceOrientationScopeImpl : DeviceOrientationScope {
+internal class DeviceOrientationScopeImpl : DeviceOrientationScope {
     override var orientation: Orientation by mutableStateOf(Orientation.Zero)
         private set
 
@@ -24,33 +14,11 @@ private class DeviceOrientationScopeImpl : DeviceOrientationScope {
     }
 }
 
-@Composable
-fun WithDeviceOrientation(
-    content: @Composable (DeviceOrientationScope.() -> Unit),
-) {
-    val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
-
-    val scope = remember {
-        DeviceOrientationScopeImpl()
-    }
-    val sensorManager = getOrientationSensorManager {
-        scope.updateOrientation(it)
-    }
-
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                sensorManager.start()
-            } else if (event == Lifecycle.Event.ON_PAUSE) {
-                sensorManager.stop()
-            }
-        }
-
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
-    }
-
-    content(scope)
+interface DeviceOrientationScope {
+    val orientation: Orientation
 }
+
+@Composable
+expect fun WithDeviceOrientation(
+    content: @Composable (DeviceOrientationScope.() -> Unit),
+)

--- a/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.ios.kt
+++ b/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.ios.kt
@@ -1,0 +1,53 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import platform.CoreMotion.CMMotionManager
+import platform.Foundation.NSOperationQueue
+
+@Composable
+internal actual fun getOrientationSensorManager(
+    onOrientationChanged: (Orientation) -> Unit,
+): OrientationSensorManager {
+    return remember(onOrientationChanged) {
+        IosOrientationSensorManager(
+            onOrientationChanged = onOrientationChanged,
+        )
+    }
+}
+
+internal class IosOrientationSensorManager(
+    override val onOrientationChanged: (Orientation) -> Unit,
+) : OrientationSensorManager {
+    private val motionManager = CMMotionManager()
+
+    override fun start() {
+        if (!motionManager.deviceMotionAvailable) {
+            return
+        }
+        NSOperationQueue.mainQueue().let { queue ->
+            motionManager.startDeviceMotionUpdatesToQueue(
+                queue,
+            ) { motion, _ ->
+                if (motion == null) {
+                    return@startDeviceMotionUpdatesToQueue
+                }
+                onOrientationChanged(
+                    Orientation(
+                        azimuth = motion.attitude.yaw.toFloat(),
+                        // Unlike Android, iOS uses a left-handed coordinate system, so we need to invert the pitch value.
+                        pitch = -motion.attitude.pitch.toFloat(),
+                        roll = motion.attitude.roll.toFloat(),
+                    ),
+                )
+            }
+        }
+    }
+
+    override fun stop() {
+        if (!motionManager.deviceMotionActive) {
+            return
+        }
+        motionManager.stopDeviceMotionUpdates()
+    }
+}

--- a/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.ios.kt
+++ b/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.ios.kt
@@ -1,0 +1,40 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+actual fun WithDeviceOrientation(
+    content: @Composable (DeviceOrientationScope.() -> Unit),
+) {
+    val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+
+    val scope = remember {
+        DeviceOrientationScopeImpl()
+    }
+    val sensorManager = getOrientationSensorManager {
+        scope.updateOrientation(it)
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                sensorManager.start()
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
+                sensorManager.stop()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    content(scope)
+}

--- a/core/droidkaigiui/src/jvmMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.jvm.kt
+++ b/core/droidkaigiui/src/jvmMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.jvm.kt
@@ -1,0 +1,19 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun getOrientationSensorManager(
+    onOrientationChanged: (Orientation) -> Unit,
+): OrientationSensorManager = object : OrientationSensorManager {
+    override val onOrientationChanged: (Orientation) -> Unit
+        get() = { Orientation.Zero }
+
+    override fun start() {
+        // NOOP
+    }
+
+    override fun stop() {
+        // NOOP
+    }
+}

--- a/core/droidkaigiui/src/jvmMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.jvm.kt
+++ b/core/droidkaigiui/src/jvmMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/WithDeviceOrientation.jvm.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun WithDeviceOrientation(
+    content: @Composable (DeviceOrientationScope.() -> Unit),
+) {
+    // NOOP
+    content(
+        object : DeviceOrientationScope {
+            override val orientation: Orientation
+                get() = Orientation.Zero
+        },
+    )
+}

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/HologramaticEffectModifier.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/HologramaticEffectModifier.kt
@@ -1,0 +1,174 @@
+package io.github.confsched.profile
+
+import androidx.annotation.FloatRange
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.droidkaigiui.DeviceOrientationScope
+import io.github.droidkaigi.confsched.droidkaigiui.Orientation
+import kotlin.math.absoluteValue
+
+fun Modifier.hologramaticEffect(deviceOrientationScope: DeviceOrientationScope) = this then HologramaticEffectElement(
+    orientation = deviceOrientationScope.orientation,
+)
+
+private data class HologramaticEffectElement(
+    private val orientation: Orientation,
+) : ModifierNodeElement<HologramaticEffectNode>() {
+    override fun create(): HologramaticEffectNode {
+        return HologramaticEffectNode(orientation)
+    }
+
+    override fun update(node: HologramaticEffectNode) {
+        node.orientation = orientation
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "HologramaticEffectNode"
+        properties["orientation"] = orientation
+    }
+}
+
+private data class HologramaticEffectNode(
+    var orientation: Orientation,
+) : Modifier.Node(),
+    DrawModifierNode {
+
+    override fun ContentDrawScope.draw() {
+        val pitchDegree = radianToDegree(orientation.pitch)
+        val rollDegree = radianToDegree(orientation.roll)
+
+        val pitchRatio = pitchDegree / 90f
+        val rollRatio = rollDegree / 180f
+
+        drawInFrontOf {
+            DrawPathConfigs.forEach { config ->
+                translate(
+                    left = -(size.width * 0.5f) * rollRatio / 2f,
+                    top = (size.height * 0.5f) * pitchRatio * config.speed,
+                ) {
+                    if (rollDegree in -80f..80f) {
+                        val alpha = config.alpha * (80f - rollDegree.absoluteValue) / 80f
+                        val offset = config.offset.toPx()
+
+                        drawRect(
+                            topLeft = Offset(
+                                -size.width * 0.5f,
+                                -size.height * 0.5f,
+                            ),
+                            size = Size(
+                                size.width * 2f,
+                                size.height * 2f,
+                            ),
+                            brush = Brush.linearGradient(
+                                colorStops = arrayOf(
+                                    0.0f to Transparent,
+                                    0.45f to Transparent,
+                                    0.5f - config.width / 2f to config.startColor,
+                                    0.5f to Color.White,
+                                    0.5f + config.width / 2f to config.endColor,
+                                    0.55f to Transparent,
+                                    1.0f to Transparent,
+                                ),
+                                start = Offset(
+                                    offset.coerceAtMost(0f),
+                                    offset.coerceAtMost(0f),
+                                ),
+                                end = Offset(
+                                    size.width * 2.0f + offset.coerceAtLeast(0f),
+                                    size.width * 2.0f + offset.coerceAtLeast(0f),
+                                ),
+                            ),
+                            alpha = alpha,
+                            blendMode = BlendMode.Lighten,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun radianToDegree(radian: Float): Float {
+        return (radian * 180f / Pi).toFloat()
+    }
+
+    private data class DrawPathConfig(
+        val offset: Dp,
+        val startColor: Color,
+        val endColor: Color,
+        @param:FloatRange(from = 0.0, to = 0.1)
+        val width: Float,
+        @param:FloatRange(from = 0.0, to = 1.0)
+        val alpha: Float,
+        @param:FloatRange(from = 0.0, to = 1.0)
+        val speed: Float,
+    ) {
+        constructor(
+            offset: Dp,
+            color: Color,
+            width: Float,
+            alpha: Float,
+            speed: Float,
+        ) : this(
+            offset = offset,
+            startColor = color,
+            endColor = color,
+            width = width,
+            alpha = alpha,
+            speed = speed,
+        )
+    }
+
+    companion object {
+
+        private const val Pi = 3.14159265359
+
+        private val Transparent = Color(0, 0, 0, 0)
+        private val LightGreen = Color(0xFF45E761)
+        private val LightPink = Color(0xFFFF53CF)
+        private val LightPurple = Color(0xFF9B51E0)
+        private val LightBlue = Color(0xFF44ADE7)
+
+        private val DrawPathConfigs = listOf(
+            DrawPathConfig(
+                offset = ((-450).dp),
+                startColor = LightGreen,
+                endColor = LightPink,
+                width = 0.03f,
+                alpha = 0.3f,
+                speed = 1.0f,
+            ),
+            DrawPathConfig(
+                offset = (-200).dp,
+                color = LightPurple,
+                width = 0.02f,
+                alpha = 0.4f,
+                speed = 0.6f,
+            ),
+            DrawPathConfig(
+                offset = 50.dp,
+                color = LightBlue,
+                width = 0.01f,
+                alpha = 0.5f,
+                speed = 0.3f,
+            ),
+        )
+    }
+}
+
+private fun ContentDrawScope.drawInFrontOf(
+    frontContent: ContentDrawScope.() -> Unit,
+) {
+    drawContent()
+    frontContent()
+}

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/TiltEffectModifier.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/TiltEffectModifier.kt
@@ -19,10 +19,9 @@ import kotlin.math.roundToInt
  * @param deviceOrientationScope The scope containing the device orientation information.
  * @return A [Modifier] with the tilt effect applied.
  */
-fun Modifier.tiltEffect(deviceOrientationScope: DeviceOrientationScope) =
-    this then TiltEffectElement(
-        orientation = deviceOrientationScope.orientation,
-    )
+fun Modifier.tiltEffect(deviceOrientationScope: DeviceOrientationScope) = this then TiltEffectElement(
+    orientation = deviceOrientationScope.orientation,
+)
 
 /**
  * Modifier element to handle tilt effect based on device orientation.
@@ -55,7 +54,8 @@ private data class TiltEffectNode(
     var orientation: Orientation,
     var previousTiltRoll: Float = 0f,
     var previousTiltPitch: Float = 0f,
-) : Modifier.Node(), LayoutModifierNode {
+) : Modifier.Node(),
+    LayoutModifierNode {
 
     /** Maximum tilt angle applied to the element. */
     private val maxTiltAngle = 5f

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/TiltEffectModifier.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/TiltEffectModifier.kt
@@ -1,0 +1,135 @@
+package io.github.confsched.profile
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Constraints
+import io.github.droidkaigi.confsched.droidkaigiui.DeviceOrientationScope
+import io.github.droidkaigi.confsched.droidkaigiui.Orientation
+import kotlin.math.PI
+import kotlin.math.roundToInt
+
+/**
+ * Extension function to apply tilt effect based on device orientation.
+ *
+ * @param deviceOrientationScope The scope containing the device orientation information.
+ * @return A [Modifier] with the tilt effect applied.
+ */
+fun Modifier.tiltEffect(deviceOrientationScope: DeviceOrientationScope) =
+    this then TiltEffectElement(
+        orientation = deviceOrientationScope.orientation,
+    )
+
+/**
+ * Modifier element to handle tilt effect based on device orientation.
+ *
+ * @property orientation The current orientation of the device.
+ */
+private data class TiltEffectElement(
+    private val orientation: Orientation,
+) : ModifierNodeElement<TiltEffectNode>() {
+    override fun create() = TiltEffectNode(orientation)
+
+    override fun update(node: TiltEffectNode) {
+        node.orientation = orientation
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "TiltEffectNode"
+        properties["orientation"] = orientation
+    }
+}
+
+/**
+ * A node to apply tilt effect to a layout based on device orientation.
+ *
+ * @property orientation The current orientation of the device.
+ * @property previousTiltRoll The last computed X-axis tilt value (roll), used for stabilization.
+ * @property previousTiltPitch The last computed Y-axis tilt value (pitch), used for stabilization.
+ */
+private data class TiltEffectNode(
+    var orientation: Orientation,
+    var previousTiltRoll: Float = 0f,
+    var previousTiltPitch: Float = 0f,
+) : Modifier.Node(), LayoutModifierNode {
+
+    /** Maximum tilt angle applied to the element. */
+    private val maxTiltAngle = 5f
+
+    /** The minimum and maximum allowable angles for tilt to be considered valid. */
+    private val minTiltAngle = -75f
+    private val maxTiltAngleRange = 75f
+
+    /** Computes the pitch in degrees from the current orientation in radians. */
+    private val pitchDegree: Float
+        get() = radianToDegree(orientation.pitch)
+
+    /** Computes the roll in degrees from the current orientation in radians. */
+    private val rollDegree: Float
+        get() = radianToDegree(orientation.roll)
+
+    /** Checks if the pitch is within the valid tilt range. */
+    private val isPitchWithinValidRange: Boolean
+        get() = pitchDegree in minTiltAngle..maxTiltAngleRange
+
+    /** Checks if the roll is within the valid tilt range. */
+    private val isRollWithinValidRange: Boolean
+        get() = rollDegree in minTiltAngle..maxTiltAngleRange
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+
+        val (tiltRoll, tiltPitch) = calculateTilt()
+
+        return layout(placeable.width, placeable.height) {
+            placeable.placeRelativeWithLayer(
+                x = tiltRoll.roundToInt(),
+                y = tiltPitch.roundToInt(),
+                layerBlock = {
+                    // > Note that this definition of yaw, pitch and roll is different from the traditional definition used in aviation where the X axis is along the long side of the plane (tail to nose).
+                    // https://developer.android.com/reference/android/hardware/SensorListener.html
+                    rotationX = tiltPitch
+                    rotationY = tiltRoll
+                },
+            )
+        }
+    }
+
+    /**
+     * Calculates the tilt values (roll and pitch) based on the current device orientation.
+     * If the orientation is out of the valid range, the last known values are used.
+     *
+     * @return A pair of Floats representing the roll and pitch tilt values.
+     */
+    private fun calculateTilt(): Pair<Float, Float> {
+        return if (isPitchWithinValidRange && isRollWithinValidRange) {
+            val tiltPitch = (pitchDegree / 90f) * maxTiltAngle
+            val tiltRoll = (rollDegree / 90f).coerceIn(-1f, 1f) * maxTiltAngle
+
+            // Save the current values for future use
+            previousTiltRoll = tiltRoll
+            previousTiltPitch = tiltPitch
+
+            tiltRoll to tiltPitch
+        } else {
+            previousTiltRoll to previousTiltPitch
+        }
+    }
+
+    /**
+     * Converts radians to degrees.
+     *
+     * @param radian The value in radians to convert.
+     * @return The value converted to degrees.
+     */
+    private fun radianToDegree(radian: Float): Float {
+        return (radian * 180f / PI).toFloat()
+    }
+}

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import io.github.confsched.profile.ProfileUiState
+import io.github.confsched.profile.hologramaticEffect
 import io.github.confsched.profile.tiltEffect
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.droidkaigiui.WithDeviceOrientation
@@ -121,6 +122,7 @@ private fun ProfileCard(
                     profileImageBitmap = uiState.profileImageBitmap,
                     nickName = uiState.profile.nickName,
                     occupation = uiState.profile.occupation,
+                    modifier = Modifier.hologramaticEffect(this@WithDeviceOrientation),
                 )
             } else {
                 ProfileCardBack(

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
@@ -4,14 +4,11 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -20,13 +17,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.BlurredEdgeTreatment
-import androidx.compose.ui.draw.blur
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.unit.dp
 import io.github.confsched.profile.ProfileUiState
+import io.github.confsched.profile.tiltEffect
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
+import io.github.droidkaigi.confsched.droidkaigiui.WithDeviceOrientation
 import io.github.droidkaigi.confsched.model.profile.Profile
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -92,47 +87,50 @@ private fun ProfileCard(
     interactionsEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Card(
-        modifier = modifier
-            .clickable(
-                enabled = interactionsEnabled,
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-            ) {
-                onFlippedChange(!isFlipped)
+    WithDeviceOrientation {
+        Card(
+            modifier = modifier
+                .clickable(
+                    enabled = interactionsEnabled,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) {
+                    onFlippedChange(!isFlipped)
+                }
+                .draggable(
+                    enabled = interactionsEnabled,
+                    orientation = Orientation.Horizontal,
+                    state = rememberDraggableState { delta ->
+                        if (isFlipped && delta > ChangeFlipCardDeltaThreshold) {
+                            onFlippedChange(false)
+                        }
+                        if (!isFlipped && delta < -ChangeFlipCardDeltaThreshold) {
+                            onFlippedChange(true)
+                        }
+                    },
+                )
+                .graphicsLayer {
+                    rotationY = rotation
+                    cameraDistance = 12f * density
+                }
+                .tiltEffect(this@WithDeviceOrientation),
+        ) {
+            if (rotation < 90f) {
+                ProfileCardFront(
+                    theme = uiState.profile.theme,
+                    profileImageBitmap = uiState.profileImageBitmap,
+                    nickName = uiState.profile.nickName,
+                    occupation = uiState.profile.occupation,
+                )
+            } else {
+                ProfileCardBack(
+                    theme = uiState.profile.theme,
+                    qrImageBitmap = uiState.qrImageBitmap,
+                    modifier = Modifier.graphicsLayer {
+                        rotationY = 180f
+                    },
+                )
             }
-            .draggable(
-                enabled = interactionsEnabled,
-                orientation = Orientation.Horizontal,
-                state = rememberDraggableState { delta ->
-                    if (isFlipped && delta > ChangeFlipCardDeltaThreshold) {
-                        onFlippedChange(false)
-                    }
-                    if (!isFlipped && delta < -ChangeFlipCardDeltaThreshold) {
-                        onFlippedChange(true)
-                    }
-                },
-            )
-            .graphicsLayer {
-                rotationY = rotation
-                cameraDistance = 12f * density
-            },
-    ) {
-        if (rotation < 90f) {
-            ProfileCardFront(
-                theme = uiState.profile.theme,
-                profileImageBitmap = uiState.profileImageBitmap,
-                nickName = uiState.profile.nickName,
-                occupation = uiState.profile.occupation,
-            )
-        } else {
-            ProfileCardBack(
-                theme = uiState.profile.theme,
-                qrImageBitmap = uiState.qrImageBitmap,
-                modifier = Modifier.graphicsLayer {
-                    rotationY = 180f
-                },
-            )
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #353

## Overview (Required)

- This code is essentially a copy-paste of last year's implementation.
- While Figma's requirements for sparkle have changed since last year, there's no realistic chance of implementing the new version within the remaining time, so we've kept last year's version.
- Additionally, testing is currently blocked by another person's task, so it's not included in this PR.
- We haven't been able to verify functionality on iOS this year because we can't install apps on actual devices.

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/910
- https://github.com/DroidKaigi/conference-app-2024/pull/750
- #157
- https://www.figma.com/design/1YjyMBNVLEGcHP4W7UNzDE/DroidKaigi-2025-App-UI?node-id=55884-7807&t=Ip7JuwznH0cykPlh-4

## Movie (Optional)
Android | iOS
:--: | :--:
<video src="https://github.com/user-attachments/assets/e4e392b8-edf7-43f2-ad2e-8165b6719ff0" width="300" > | UnKnown.