### PR TITLE
Fix to prevent hiding content by FAB on TimetableItemDetailScreen

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -1,16 +1,22 @@
 package io.github.droidkaigi.confsched.sessions
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeGestures
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
@@ -46,6 +52,7 @@ fun TimetableItemDetailScreen(
 ) {
     ProvideRoomTheme(uiState.timetableItem.room.roomTheme) {
         val listState = rememberLazyListState()
+        var fabHeight by remember { mutableStateOf(0.dp) }
         Scaffold(
             topBar = {
                 TimetableItemDetailTopAppBar(
@@ -53,6 +60,7 @@ fun TimetableItemDetailScreen(
                 )
             },
             floatingActionButton = {
+                val density = LocalDensity.current
                 TimetableItemDetailFloatingActionButtonMenu(
                     isBookmarked = uiState.isBookmarked,
                     slideUrl = uiState.timetableItem.asset.slideUrl,
@@ -62,7 +70,11 @@ fun TimetableItemDetailScreen(
                     onShareClick = { onShareClick(uiState.timetableItem) },
                     onViewSlideClick = onLinkClick,
                     onWatchVideoClick = onLinkClick,
-                    modifier = Modifier.padding(bottom = WindowInsets.safeGestures.asPaddingValues().calculateBottomPadding()),
+                    modifier = Modifier.onGloballyPositioned {
+                        with(density) {
+                            fabHeight = it.size.height.toDp()
+                        }
+                    }.padding(bottom = WindowInsets.safeGestures.asPaddingValues().calculateBottomPadding()),
                 )
             },
             contentWindowInsets = WindowInsets(),
@@ -74,7 +86,7 @@ fun TimetableItemDetailScreen(
                     .fillMaxSize()
                     .enableMouseDragScroll(listState)
                     .testTag(TimetableItemDetailScreenLazyColumnTestTag),
-                contentPadding = contentPadding + WindowInsets.navigationBars.asPaddingValues(),
+                contentPadding = contentPadding + PaddingValues(bottom = WindowInsets.safeGestures.asPaddingValues().calculateBottomPadding() + fabHeight),
             ) {
                 item {
                     TimetableItemDetailHeadline(


### PR DESCRIPTION
## Issue
- close #202

## Overview (Required)
- Added bottom padding the size of FAB to LazyColumn at TimetalbeItemDetailScreen
- Originally assigned to @dinoy-raj , but it looks took a long time, so I tried to take the task.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
| Before | After |
| :--: | :--: |
| <img width="1080" height="2400" alt="Screenshot_20250906_045220" src="https://github.com/user-attachments/assets/457fcbe8-503b-4593-a18a-346ba076169d" /> | <img width="1080" height="2400" alt="Screenshot_20250906_044949" src="https://github.com/user-attachments/assets/96e13f4f-5fbe-43c2-8c8b-718724a61c40" /> |