### PR TITLE
Remove loading icon from `ContributorItem` and `StaffItem components`

### DIFF
--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorItem.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorItem.kt
@@ -8,9 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -51,12 +48,6 @@ fun ContributorItem(
         SubcomposeAsyncImage(
             model = contributor.iconUrl,
             contentDescription = contributor.username,
-            loading = {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = contributor.username,
-                )
-            },
             modifier = Modifier
                 .size(52.dp)
                 .clip(CircleShape)

--- a/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/component/StaffItem.kt
+++ b/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/component/StaffItem.kt
@@ -7,9 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,12 +45,6 @@ fun StaffItem(
         SubcomposeAsyncImage(
             model = staff.iconUrl,
             contentDescription = staff.username,
-            loading = {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = staff.username,
-                )
-            },
             modifier = Modifier
                 .size(52.dp)
                 .clip(staffIconShape)


### PR DESCRIPTION
## Issue
- close #578

## Overview (Required)
- This change removes the custom loading icon from the `ContributorItem` and `StaffItem` components; as a result, `SubcomposeAsyncImage`’s loading state will use the default indicator.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/0c87e378-0011-4266-8df1-8f8e83bd5c69" width="300" > | <video src="https://github.com/user-attachments/assets/c20a6308-dbe6-4e44-abe8-55718c1ab8ce" width="300" >
<video src="https://github.com/user-attachments/assets/3c2f7b84-2dbd-4d82-bcb4-6dfcac809eb5" width="300" > | <video src="https://github.com/user-attachments/assets/cb279c1b-e998-4c26-9636-57b8af021079" width="300" >
