### PR TITLE
Improve timetable detail talkback feedback

### DIFF
--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/sessions/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/sessions/TimetableItemDetailScreenRobot.kt
@@ -26,7 +26,6 @@ import io.github.droidkaigi.confsched.sessions.components.TargetAudienceSectionT
 import io.github.droidkaigi.confsched.sessions.components.TimetableItemDetailContentTargetAudienceSectionBottomTestTag
 import io.github.droidkaigi.confsched.sessions.components.TimetableItemDetailHeadlineTestTag
 import io.github.droidkaigi.confsched.sessions.components.TimetableItemDetailMessageRowTestTag
-import io.github.droidkaigi.confsched.sessions.components.TimetableItemDetailMessageRowTextTestTag
 import io.github.droidkaigi.confsched.testing.compose.TestDefaultsProvider
 import io.github.droidkaigi.confsched.testing.robot.core.CaptureScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.core.DefaultCaptureScreenRobot
@@ -209,7 +208,7 @@ class TimetableItemDetailScreenRobot(
     context(composeUiTest: ComposeUiTest)
     fun checkMessageDisplayed() {
         composeUiTest
-            .onAllNodesWithTag(TimetableItemDetailMessageRowTextTestTag)
+            .onAllNodesWithTag(TimetableItemDetailMessageRowTestTag)
             .onFirst()
             .assertExists()
             .assertIsDisplayed()

--- a/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
@@ -20,11 +20,6 @@
     <string name="english">English</string>
     <string name="timetable">Timetable</string>
     <string name="content_description_share">共有</string>
-    <string name="content_description_calendar">カレンダー</string>
-    <string name="content_description_schedule">スケジュール</string>
-    <string name="content_description_location">場所</string>
-    <string name="content_description_language">言語</string>
-    <string name="content_description_category">カテゴリ</string>
     <string name="schedule_title">日時</string>
     <string name="location_title">場所</string>
     <string name="language_title">対応言語</string>

--- a/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
@@ -37,4 +37,7 @@
     <string name="go_to_timetable_detail">詳細を開く</string>
     <string name="request_full_space">フルスペースに切り替え</string>
     <string name="request_home_space">ホームスペースに切り替え</string>
+    <string name="bookmark_menu">お気に入りメニュー</string>
+    <string name="collapsed_menu">閉じた状態</string>
+    <string name="expanded_menu">開いた状態</string>
 </resources>

--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -37,4 +37,7 @@
     <string name="go_to_timetable_detail">Open details</string>
     <string name="request_full_space">Request full space</string>
     <string name="request_home_space">Request home space</string>
+    <string name="bookmark_menu">Favorite menu</string>
+    <string name="collapsed_menu">Collapsed</string>
+    <string name="expanded_menu">Expanded</string>
 </resources>

--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -20,11 +20,6 @@
     <string name="english">English</string>
     <string name="timetable">Timetable</string>
     <string name="content_description_share">Share</string>
-    <string name="content_description_calendar">Calendar</string>
-    <string name="content_description_schedule">Schedule</string>
-    <string name="content_description_location">Location</string>
-    <string name="content_description_language">Language</string>
-    <string name="content_description_category">Category</string>
     <string name="schedule_title">Date/Time</string>
     <string name="location_title">Location</string>
     <string name="language_title">Supported Languages</string>

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -61,7 +61,7 @@ fun TimetableItemDetailScreen(
                     onBackClick = onBackClick,
                     modifier = Modifier.semantics {
                         traversalIndex = -1f
-                    }
+                    },
                 )
             },
             floatingActionButton = {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
@@ -57,6 +59,9 @@ fun TimetableItemDetailScreen(
             topBar = {
                 TimetableItemDetailTopAppBar(
                     onBackClick = onBackClick,
+                    modifier = Modifier.semantics {
+                        traversalIndex = -1f
+                    }
                 )
             },
             floatingActionButton = {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailAnnounceMessage.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailAnnounceMessage.kt
@@ -13,12 +13,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
-import io.github.droidkaigi.confsched.sessions.SessionsRes
-import io.github.droidkaigi.confsched.sessions.image
-import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val TimetableItemDetailMessageRowTestTag = "TimetableItemDetailMessageRowTestTag"
@@ -32,13 +30,14 @@ fun TimetableItemDetailAnnounceMessage(
     Row(
         modifier = modifier
             .height(IntrinsicSize.Min)
-            .testTag(TimetableItemDetailMessageRowTestTag),
+            .testTag(TimetableItemDetailMessageRowTestTag)
+            .semantics(mergeDescendants = true) {},
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Icon(
             modifier = Modifier.fillMaxHeight(),
             imageVector = Icons.Filled.Info,
-            contentDescription = stringResource(SessionsRes.string.image),
+            contentDescription = null,
             tint = MaterialTheme.colorScheme.error,
         )
         Text(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailAnnounceMessage.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailAnnounceMessage.kt
@@ -20,7 +20,6 @@ import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val TimetableItemDetailMessageRowTestTag = "TimetableItemDetailMessageRowTestTag"
-const val TimetableItemDetailMessageRowTextTestTag = "TimetableItemDetailMessageRowTextTestTag"
 
 @Composable
 fun TimetableItemDetailAnnounceMessage(
@@ -41,7 +40,6 @@ fun TimetableItemDetailAnnounceMessage(
             tint = MaterialTheme.colorScheme.error,
         )
         Text(
-            modifier = Modifier.testTag(TimetableItemDetailMessageRowTextTestTag),
             text = message,
             fontSize = 16.sp,
             color = MaterialTheme.colorScheme.error,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
@@ -121,7 +121,7 @@ private fun DescriptionSection(
                     style = MaterialTheme.typography.labelLarge,
                     modifier = Modifier.semantics {
                         hideFromAccessibility()
-                    }
+                    },
                 )
             }
         }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.component.ClickableLinkText
@@ -102,7 +104,11 @@ private fun DescriptionSection(
             modifier = Modifier.testTag(DescriptionMoreButtonTestTag),
         ) {
             OutlinedButton(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .semantics {
+                        hideFromAccessibility()
+                    }
+                    .fillMaxWidth(),
                 shapes = ButtonDefaults.shapes(),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = LocalRoomTheme.current.dimColor,
@@ -114,6 +120,9 @@ private fun DescriptionSection(
                     text = stringResource(SessionsRes.string.read_more),
                     style = MaterialTheme.typography.labelLarge,
                     color = LocalRoomTheme.current.primaryColor,
+                    modifier = Modifier.semantics {
+                        hideFromAccessibility()
+                    }
                 )
             }
         }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailContent.kt
@@ -10,9 +10,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -103,23 +103,22 @@ private fun DescriptionSection(
             exit = fadeOut(),
             modifier = Modifier.testTag(DescriptionMoreButtonTestTag),
         ) {
-            OutlinedButton(
+            ElevatedButton(
                 modifier = Modifier
                     .semantics {
                         hideFromAccessibility()
                     }
                     .fillMaxWidth(),
                 shapes = ButtonDefaults.shapes(),
-                colors = ButtonDefaults.buttonColors(
+                colors = ButtonDefaults.elevatedButtonColors(
                     containerColor = LocalRoomTheme.current.dimColor,
+                    contentColor = LocalRoomTheme.current.primaryColor,
                 ),
-                border = null,
                 onClick = { isExpand = true },
             ) {
                 Text(
                     text = stringResource(SessionsRes.string.read_more),
                     style = MaterialTheme.typography.labelLarge,
-                    color = LocalRoomTheme.current.primaryColor,
                     modifier = Modifier.semantics {
                         hideFromAccessibility()
                     }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailFloatingMenu.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailFloatingMenu.kt
@@ -28,6 +28,9 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.droidkaigiui.DroidkaigiuiRes
@@ -39,6 +42,9 @@ import io.github.droidkaigi.confsched.model.sessions.TimetableItem
 import io.github.droidkaigi.confsched.model.sessions.fake
 import io.github.droidkaigi.confsched.sessions.SessionsRes
 import io.github.droidkaigi.confsched.sessions.add_to_calendar
+import io.github.droidkaigi.confsched.sessions.bookmark_menu
+import io.github.droidkaigi.confsched.sessions.collapsed_menu
+import io.github.droidkaigi.confsched.sessions.expanded_menu
 import io.github.droidkaigi.confsched.sessions.share_link
 import io.github.droidkaigi.confsched.sessions.slide
 import io.github.droidkaigi.confsched.sessions.video
@@ -109,10 +115,16 @@ private fun TimetableItemDetailFloatingActionButtonMenu(
     FloatingActionButtonMenu(
         expanded = expanded,
         button = {
+            val fabMenuStateDescription = stringResource(if (expanded) SessionsRes.string.expanded_menu else SessionsRes.string.collapsed_menu)
+            val fabMenuDescription = stringResource(SessionsRes.string.bookmark_menu)
             ToggleFloatingActionButton(
                 checked = expanded,
                 onCheckedChange = onExpandedChange,
                 containerColor = { _ -> menuItemContainerColor },
+                modifier = Modifier.semantics {
+                    stateDescription = fabMenuStateDescription
+                    contentDescription = fabMenuDescription
+                },
             ) {
                 if (expanded) {
                     Icon(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailHeadline.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailHeadline.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -97,7 +98,11 @@ fun TimetableItemDetailHeadline(
         }
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            modifier = Modifier.testTag(TimetableItemDetailHeadlineTestTag),
+            modifier = Modifier
+                .testTag(TimetableItemDetailHeadlineTestTag)
+                .semantics {
+                    heading()
+                },
             text = timetableItem.title.getByLang(currentLang),
             style = MaterialTheme.typography.headlineSmall,
         )
@@ -105,6 +110,7 @@ fun TimetableItemDetailHeadline(
         timetableItem.speakers.forEach { speaker ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.semantics(mergeDescendants = true) {}
             ) {
                 SubcomposeAsyncImage(
                     model = speaker.iconUrl,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailHeadline.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailHeadline.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -29,6 +30,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.unit.dp
@@ -144,15 +149,20 @@ private fun LanguageSwitcher(
     val lastIndex = availableLangs.size - 1
 
     Row(
-        modifier = modifier,
+        modifier = modifier.selectableGroup(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         availableLangs.forEachIndexed { index, lang ->
             val isSelected = normalizedCurrentLang == lang
+
             TextButton(
                 onClick = { onLanguageSelect(lang) },
                 shapes = ButtonDefaults.shapes(),
                 contentPadding = PaddingValues(12.dp),
+                modifier = Modifier.semantics {
+                    role = Role.RadioButton
+                    selected = isSelected
+                }
             ) {
                 val contentColor = if (isSelected) {
                     LocalRoomTheme.current.primaryColor
@@ -175,7 +185,7 @@ private fun LanguageSwitcher(
                             Lang.JAPANESE -> SessionsRes.string.japanese
                             Lang.ENGLISH,
                             Lang.MIXED,
-                            -> SessionsRes.string.english
+                                -> SessionsRes.string.english
                         },
                     ),
                     color = contentColor,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailHeadline.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailHeadline.kt
@@ -110,7 +110,7 @@ fun TimetableItemDetailHeadline(
         timetableItem.speakers.forEach { speaker ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.semantics(mergeDescendants = true) {}
+                modifier = Modifier.semantics(mergeDescendants = true) {},
             ) {
                 SubcomposeAsyncImage(
                     model = speaker.iconUrl,
@@ -168,7 +168,7 @@ private fun LanguageSwitcher(
                 modifier = Modifier.semantics {
                     role = Role.RadioButton
                     selected = isSelected
-                }
+                },
             ) {
                 val contentColor = if (isSelected) {
                     LocalRoomTheme.current.primaryColor
@@ -191,7 +191,7 @@ private fun LanguageSwitcher(
                             Lang.JAPANESE -> SessionsRes.string.japanese
                             Lang.ENGLISH,
                             Lang.MIXED,
-                                -> SessionsRes.string.english
+                            -> SessionsRes.string.english
                         },
                     ),
                     color = contentColor,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableItemDetailSummaryCard.kt
@@ -46,10 +46,6 @@ import io.github.droidkaigi.confsched.model.sessions.TimetableItem
 import io.github.droidkaigi.confsched.model.sessions.fake
 import io.github.droidkaigi.confsched.sessions.SessionsRes
 import io.github.droidkaigi.confsched.sessions.category_title
-import io.github.droidkaigi.confsched.sessions.content_description_category
-import io.github.droidkaigi.confsched.sessions.content_description_language
-import io.github.droidkaigi.confsched.sessions.content_description_location
-import io.github.droidkaigi.confsched.sessions.content_description_schedule
 import io.github.droidkaigi.confsched.sessions.language_title
 import io.github.droidkaigi.confsched.sessions.location_title
 import io.github.droidkaigi.confsched.sessions.schedule_title
@@ -76,7 +72,6 @@ fun TimetableItemDetailSummaryCard(
                     SummaryCardTextTag.plus(stringResource(SessionsRes.string.schedule_title)),
                 ),
             imageVector = Icons.Outlined.Schedule,
-            contentDescription = stringResource(SessionsRes.string.content_description_schedule),
             title = stringResource(SessionsRes.string.schedule_title),
             description = timetableItem.formattedDateTimeString,
             isCancelledSession = timetableItem.isCancelledSession,
@@ -89,7 +84,6 @@ fun TimetableItemDetailSummaryCard(
                     SummaryCardTextTag.plus(stringResource(SessionsRes.string.location_title)),
                 ),
             imageVector = Icons.Outlined.LocationOn,
-            contentDescription = stringResource(SessionsRes.string.content_description_location),
             title = stringResource(SessionsRes.string.location_title),
             description = timetableItem.room.nameAndFloor,
             isCancelledSession = timetableItem.isCancelledSession,
@@ -102,7 +96,6 @@ fun TimetableItemDetailSummaryCard(
                     SummaryCardTextTag.plus(stringResource(SessionsRes.string.language_title)),
                 ),
             imageVector = Icons.Outlined.Language,
-            contentDescription = stringResource(SessionsRes.string.content_description_language),
             title = stringResource(SessionsRes.string.language_title),
             description = timetableItem.getSupportedLangString(
                 getDefaultLocale() == Locale.JAPAN,
@@ -117,7 +110,6 @@ fun TimetableItemDetailSummaryCard(
                     SummaryCardTextTag.plus(stringResource(SessionsRes.string.category_title)),
                 ),
             imageVector = Icons.Outlined.Category,
-            contentDescription = stringResource(SessionsRes.string.content_description_category),
             title = stringResource(SessionsRes.string.category_title),
             description = timetableItem.category.title.currentLangTitle,
             isCancelledSession = timetableItem.isCancelledSession,
@@ -128,7 +120,6 @@ fun TimetableItemDetailSummaryCard(
 @Composable
 private fun SummaryCardText(
     imageVector: ImageVector,
-    contentDescription: String,
     title: String,
     description: String,
     isCancelledSession: Boolean,
@@ -149,7 +140,6 @@ private fun SummaryCardText(
 
     val inlineContent = createInlineContentsMapForSummaryCardTexts(
         imageVector = imageVector,
-        contentDescription = contentDescription,
         iconInlineContentId = iconInlineContentId,
         spacer8dpInlineContentId = spacer8dpInlineContentId,
         spacer12dpInlineContentId = spacer12dpInlineContentId,
@@ -176,7 +166,7 @@ private fun createSummaryCardTextAnnotatedString(
     spacer12dpInlineContentId: String,
 ): AnnotatedString {
     return buildAnnotatedString {
-        appendInlineContent(id = iconInlineContentId, alternateText = "[icon]")
+        appendInlineContent(id = iconInlineContentId)
         appendInlineContent(id = spacer8dpInlineContentId, alternateText = " ")
         withStyle(
             style = SpanStyle(
@@ -209,7 +199,6 @@ private fun createSummaryCardTextAnnotatedString(
 @Composable
 private fun createInlineContentsMapForSummaryCardTexts(
     imageVector: ImageVector,
-    contentDescription: String,
     iconInlineContentId: String,
     spacer8dpInlineContentId: String,
     spacer12dpInlineContentId: String,
@@ -224,7 +213,7 @@ private fun createInlineContentsMapForSummaryCardTexts(
             children = {
                 Icon(
                     imageVector = imageVector,
-                    contentDescription = contentDescription,
+                    contentDescription = null,
                     tint = LocalRoomTheme.current.primaryColor,
                 )
             },


### PR DESCRIPTION
## Issue
- #506

## Overview (Required)
- Improved Talkback feedback and traversal order for timetable detail.
- Read more button has been adjusted to match Figma's specifications.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/d817b6a4-fafe-46fd-939e-a8443718aed3" width="300" /> | <video src="https://github.com/user-attachments/assets/a2b61d31-9ed1-406c-849a-6b749794a0c9" width="300" />

