### PR TITLE
refactor: extract font family selection logic into separate composable

### DIFF
--- a/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/AppGraph.kt
+++ b/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/AppGraph.kt
@@ -6,6 +6,7 @@ import io.github.droidkaigi.confsched.about.LicensesScreenContext
 import io.github.droidkaigi.confsched.contributors.ContributorsScreenContext
 import io.github.droidkaigi.confsched.eventmap.EventMapScreenContext
 import io.github.droidkaigi.confsched.favorites.FavoritesScreenContext
+import io.github.droidkaigi.confsched.model.settings.SettingsSubscriptionKey
 import io.github.droidkaigi.confsched.sessions.SearchScreenContext
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenContext
 import io.github.droidkaigi.confsched.sessions.TimetableScreenContext
@@ -25,4 +26,8 @@ interface AppGraph :
     ProfileScreenContext.Factory,
     LicensesScreenContext.Factory,
     EventMapScreenContext.Factory,
-    SettingsScreenContext.Factory
+    SettingsScreenContext.Factory {
+
+    // NOTE: This is used in KaigiApp to apply user selected font family in the entire app.
+    val settingsSubscriptionKey: SettingsSubscriptionKey
+}

--- a/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -45,7 +45,7 @@ fun KaigiApp() {
 context(appGraph: AppGraph)
 private fun rememberKaigiFontFamily(): FontFamily? {
     val subscription = rememberSubscription(
-        key = appGraph.createSettingsScreenContext().settingsSubscriptionKey,
+        key = appGraph.settingsSubscriptionKey,
         select = { it.useKaigiFontFamily },
     )
     return subscription.reply.map {

--- a/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -17,8 +17,6 @@ import soil.query.SwrCacheScope
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SwrClientProvider
 import soil.query.compose.rememberSubscription
-import soil.query.core.getOrNull
-import soil.query.core.map
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalSoilQueryApi::class)
 @Composable
@@ -48,12 +46,11 @@ private fun rememberKaigiFontFamily(): FontFamily? {
         key = appGraph.settingsSubscriptionKey,
         select = { it.useKaigiFontFamily },
     )
-    return subscription.reply.map {
-        when (it) {
-            KaigiFontFamily.ChangoRegular -> changoFontFamily()
-            KaigiFontFamily.RobotoRegular -> robotoRegularFontFamily()
-            KaigiFontFamily.RobotoMedium -> robotoMediumFontFamily()
-            KaigiFontFamily.SystemDefault -> null
-        }
-    }.getOrNull()
+    return when (subscription.data) {
+        KaigiFontFamily.ChangoRegular -> changoFontFamily()
+        KaigiFontFamily.RobotoRegular -> robotoRegularFontFamily()
+        KaigiFontFamily.RobotoMedium -> robotoMediumFontFamily()
+        KaigiFontFamily.SystemDefault -> null
+        null -> null
+    }
 }


### PR DESCRIPTION
I'm the author of the Soil library. Thank you so much for adopting Soil in this project! 
I saw how the project uses Soil and wanted to share a different implementation style that might be interesting 🙌 

## Overview (Required)
This PR refactors the font family selection logic to remove dependency on SettingsScreenContext and simplify the data handling approach. 

~~This PR extracts the font family selection logic into a separate composable and leverages Soil Query's `reply.map(...).getOrNull()` pattern for cleaner data handling.~~

<details>
<summary>Not adopted: `reply.map(...).getOrNull()` pattern approach</summary>

```kotlin
// Before
        val kaigiFontFamily = if (subscription.isSuccess) {
            when (subscription.data) {
                KaigiFontFamily.ChangoRegular -> changoFontFamily()
                KaigiFontFamily.RobotoRegular -> robotoRegularFontFamily()
                KaigiFontFamily.RobotoMedium -> robotoMediumFontFamily()
                KaigiFontFamily.SystemDefault -> null
                null -> null
            }
        } else {
            null
        }

// After
    val kaigiFontFamily = subscription.reply.map {
        when (it) {
            KaigiFontFamily.ChangoRegular -> changoFontFamily()
            KaigiFontFamily.RobotoRegular -> robotoRegularFontFamily()
            KaigiFontFamily.RobotoMedium -> robotoMediumFontFamily()
            KaigiFontFamily.SystemDefault -> null
        }
    }.getOrNull()
```


## Links
- https://api.soil-kt.com/soil-query-core/soil.query.core/-reply/

</details>