### PR TITLE
fix ios arm64 build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # kotlin
 kotlin.code.style=official
-kotlin.native.cacheKind.iosSimulatorArm64=none
+kotlin.native.cacheKind=none
 # roborazzi
 roborazzi.test.record=true
 roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Fixes iOS Arm64 Build failed on Xcode

```
Undefined symbols for architecture arm64:
  "_kfun:androidx.compose.runtime#androidx_compose_runtime_ProvidedValue$stableprop_getter$artificial(){}kotlin.Int", referenced from:
      _kfun:soil.plant.compose.reacty#ErrorBoundary(androidx.compose.ui.Modifier?;kotlin.Function4<androidx.compose.foundation.layout.BoxScope,soil.plant.compose.reacty.ErrorBoundaryContext,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>?;kotlin.Function1<kotlin.Throwable,kotlin.Unit>?;kotlin.Function0<kotlin.Unit>?;soil.plant.compose.reacty.ErrorBoundaryState?;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){} in shared[3100](libcom.soil-kt.soil:soil-reacty-cache.a.o)
      _kfun:soil.plant.compose.reacty#Suspense(kotlin.Function3<androidx.compose.foundation.layout.BoxScope,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.ui.Modifier?;soil.plant.compose.reacty.SuspenseState?;kotlin.time.Duration;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){} in shared[3100](libcom.soil-kt.soil:soil-reacty-cache.a.o)
      _kfun:soil.query.compose#SwrClientProvider(soil.query.SwrClientPlus;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){} in shared[3103](libcom.soil-kt.soil:soil-query-compose-cache.a.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
