### PR TITLE
Animation when remove favorite

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableList.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/session/TimetableList.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -21,6 +20,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.lazy.LazyColumn
@@ -100,7 +100,7 @@ fun TimetableList(
 
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier = Modifier.animateItem()
+                    modifier = Modifier.animateItem(),
                 ) {
                     TimetableTimeSlot(
                         startTimeText = timeSlot.startTimeString,
@@ -118,28 +118,28 @@ fun TimetableList(
                                 initialScale = 0.95f,
                                 animationSpec = spring(
                                     dampingRatio = Spring.DampingRatioMediumBouncy,
-                                    stiffness = Spring.StiffnessLow
-                                )
+                                    stiffness = Spring.StiffnessLow,
+                                ),
                             )
                             val exit = fadeOut(animationSpec = tween(200)) + scaleOut(
                                 targetScale = 0.95f,
                                 animationSpec = spring(
                                     dampingRatio = Spring.DampingRatioNoBouncy,
-                                    stiffness = Spring.StiffnessMedium
-                                )
+                                    stiffness = Spring.StiffnessMedium,
+                                ),
                             )
                             enter.togetherWith(exit)
                         },
-                        label = "TimetableItemsAnimation"
+                        label = "TimetableItemsAnimation",
                     ) { items ->
                         Column(
                             verticalArrangement = Arrangement.spacedBy(12.dp),
-                            modifier = Modifier.fillMaxSize()
+                            modifier = Modifier.fillMaxSize(),
                         ) {
                             items.chunked(columnCount).forEach { rowItems ->
                                 Row(
                                     horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                    modifier = Modifier.height(IntrinsicSize.Max)
+                                    modifier = Modifier.height(IntrinsicSize.Max),
                                 ) {
                                     rowItems.forEach { item ->
                                         TimetableItemCard(
@@ -151,7 +151,7 @@ fun TimetableList(
                                             onTimetableItemClick = { onTimetableItemClick(item.id) },
                                             modifier = Modifier
                                                 .weight(1f)
-                                                .fillMaxHeight()
+                                                .fillMaxHeight(),
                                         )
                                     }
                                     if (rowItems.size < columnCount) {


### PR DESCRIPTION
## Issue
- close #148 

## Overview (Required)
- add animation when remove favorite


> [!NOTE]
Animations that support adaptive layouts are difficult the current architecture that LazyColumn nested Column and Row. As a result, there are differences in animation TimeSlotItem and TimetableItem.
I understand that the issue is to use animation to make it visually easier for users to understand when removing a favorite, so I think this differences is within acceptable level.

## Movie (Optional)
Type | Before | After
:--: | :--: | :--:
Phone | <video src="https://github.com/user-attachments/assets/61faa2d3-479a-4023-985f-081e5c1bc9bb" width="300" > | <video src="https://github.com/user-attachments/assets/cb26975d-ff0a-4287-b55a-8f3af2f8b495" width="300" >
Desktop | <video src="https://github.com/user-attachments/assets/995d8d99-57a0-4ea9-98cd-cb02066da38d" width="300" > | <video src="https://github.com/user-attachments/assets/64d1220d-49ce-4d7b-b142-76fed183c2f0" width="300" >

