### PR TITLE
Add background box to TimetableItemDetailScreen for improved UI

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -98,7 +98,7 @@ fun TimetableItemDetailScreen(
                         modifier = Modifier
                             .background(roomTheme.dimColor)
                             .fillMaxWidth()
-                            .height(contentPadding.calculateTopPadding())
+                            .height(contentPadding.calculateTopPadding()),
                     )
                 }
                 item {


### PR DESCRIPTION
## Issue
- close #592 

## Overview (Required)
- place Box composable to back of AppBar
## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/0f4bb9a7-5cfc-473c-97a6-90bcbfb81de8" width="300" /> | <img src="https://github.com/user-attachments/assets/d6239ee2-48d7-40f8-83ad-4359ab7321ea" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/0af3eeaa-0f52-44f4-8574-5d8da22e7aaf" width="300" > | <video src="https://github.com/user-attachments/assets/7c5f3140-3e51-45fd-9a72-b6db552ec652" width="300" >