### PR TITLE
[iOS] fixed favorite items filter bug

### DIFF
--- a/app-ios/Native/Sources/Feature/Favorite/FavoriteScreen.swift
+++ b/app-ios/Native/Sources/Feature/Favorite/FavoriteScreen.swift
@@ -53,14 +53,14 @@ public struct FavoriteScreen: View {
                 guard let firstItem = timeGroup.items.first else { return false }
                 let calendar = Calendar.current
                 let components = calendar.dateComponents([.day], from: firstItem.timetableItem.startsAt)
-                return components.day == 12 - 1
+                return components.day == 11
             }
         case .day2:
             return presenter.favoriteTimetableItems.filter { timeGroup in
                 guard let firstItem = timeGroup.items.first else { return false }
                 let calendar = Calendar.current
                 let components = calendar.dateComponents([.day], from: firstItem.timetableItem.startsAt)
-                return components.day == 13 - 1
+                return components.day == 12
             }
         }
     }


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Fixed a bug in the filter function for the Favorite item list.
- When filtering by **9/11**, the results of **9/12** were displayed instead.
- When filtering by **9/12**, no results were displayed.
- Corrected the filtering logic so that the expected items are displayed for each date.

## Links
- N/A

## Screenshot (Optional if screenshot test is present or unrelated to UI)

### original favorite items with no filter

filter | Before | After
:--: | :--: | :--:
no filter | <img src="https://github.com/user-attachments/assets/aa0753bc-fc78-4a87-97b3-29a74b7ef9f6" width="300" /> | <img src="https://github.com/user-attachments/assets/aa0753bc-fc78-4a87-97b3-29a74b7ef9f6" width="300" />
with 9/11 filter | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-10 at 02 11 03" src="https://github.com/user-attachments/assets/99247aaf-fbaf-4ea1-b7db-1ca7a2ccc3e2" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-10 at 02 06 10" src="https://github.com/user-attachments/assets/5871abb4-6fcb-4c08-8027-ff09db85e468" />
with 9/12 filter | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-10 at 02 11 05" src="https://github.com/user-attachments/assets/ac4a183e-022d-40c9-b4cd-84f3bc2df206" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-10 at 02 06 12" src="https://github.com/user-attachments/assets/ed1605f8-cde9-451a-b905-3a04c40a3a65" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
