### PR TITLE
fix: timetable didn't retain scroll position

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -72,10 +73,10 @@ fun TimetableScreen(
         is TimetableUiState.ListTimetable -> uiState.timetable.selectedDay
         else -> DroidKaigi2025Day.ConferenceDay1
     }
-    val listStates = remember { mutableMapOf<DroidKaigi2025Day, LazyListState>() }
-    val lazyListState = listStates.getOrPut(selectedDay) {
-        LazyListState()
-    }
+
+    val conferenceDays = listOf(DroidKaigi2025Day.ConferenceDay1, DroidKaigi2025Day.ConferenceDay2)
+    val listStates = rememberListStatesByDay(conferenceDays)
+    val lazyListState = listStates.getValue(selectedDay)
 
     val completelyScrolledToTop by remember(selectedDay) {
         derivedStateOf {
@@ -192,6 +193,15 @@ fun TimetableScreen(
 
 private object TimetableDefaults {
     val dayTabWidth = 104.dp
+}
+
+@Composable
+private fun rememberListStatesByDay(
+    days: List<DroidKaigi2025Day>,
+): Map<DroidKaigi2025Day, LazyListState> {
+    return days.associateWith { day ->
+        rememberSaveable(day, saver = LazyListState.Saver) { LazyListState() }
+    }
 }
 
 @Preview

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -74,7 +74,7 @@ fun TimetableScreen(
         else -> DroidKaigi2025Day.ConferenceDay1
     }
 
-    val conferenceDays = listOf(DroidKaigi2025Day.ConferenceDay1, DroidKaigi2025Day.ConferenceDay2)
+    val conferenceDays = DroidKaigi2025Day.visibleDays()
     val listStates = rememberListStatesByDay(conferenceDays)
     val lazyListState = listStates.getValue(selectedDay)
 


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER
- I searched through issue and PR lists but couldn't find any fixes for this problem, so I'll proceed with creating the PR.

## Overview (Required)

- Currently, when you scroll in the ListTimetable screen and then navigate to another screen, the scroll position isn't preserved.
- To improve user experience, I've modified the implementation to maintain LazyListState, effectively resolving this issue.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/e2371003-4cd5-42c3-868d-f6c71f3f83ba" width="300" > | <video src="https://github.com/user-attachments/assets/c8d281f5-d913-43cc-8158-c88bf352e7f0" width="300" >
