### PR TITLE
[iOS] Move session archive buttons from FAB to dedicated section

### DIFF
--- a/app-ios/Native/Sources/Feature/TimetableDetail/Resources/Localizable.xcstrings
+++ b/app-ios/Native/Sources/Feature/TimetableDetail/Resources/Localizable.xcstrings
@@ -81,6 +81,22 @@
         }
       }
     },
+    "Archive" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archive"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブ"
+          }
+        }
+      }
+    },
     "Calendar access not granted" : {
       "localizations" : {
         "en" : {
@@ -162,6 +178,7 @@
       }
     },
     "Open presentation slides" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -257,6 +274,22 @@
         }
       }
     },
+    "Slides" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slides"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スライド"
+          }
+        }
+      }
+    },
     "Supported Languages" : {
       "localizations" : {
         "en" : {
@@ -289,6 +322,22 @@
         }
       }
     },
+    "Video" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画"
+          }
+        }
+      }
+    },
     "View list" : {
       "localizations" : {
         "en" : {
@@ -306,6 +355,7 @@
       }
     },
     "Watch video" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/app-ios/Native/Sources/Feature/TimetableDetail/Resources/Localizable.xcstrings
+++ b/app-ios/Native/Sources/Feature/TimetableDetail/Resources/Localizable.xcstrings
@@ -177,23 +177,6 @@
         }
       }
     },
-    "Open presentation slides" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open presentation slides"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "発表スライドを開く"
-          }
-        }
-      }
-    },
     "Read more" : {
       "localizations" : {
         "en" : {
@@ -350,23 +333,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一覧を見る"
-          }
-        }
-      }
-    },
-    "Watch video" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Watch video"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動画を見る"
           }
         }
       }

--- a/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
+++ b/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
@@ -189,7 +189,8 @@ public struct TimetableDetailScreen: View {
             HStack(spacing: 12) {
                 // Open slides button
                 if let slideUrlString = presenter.timetableItem.timetableItem.asset.slideUrl,
-                   let slideUrl = URL(string: slideUrlString) {
+                    let slideUrl = URL(string: slideUrlString)
+                {
                     Button {
                         showingURL = slideUrl
                     } label: {
@@ -211,7 +212,8 @@ public struct TimetableDetailScreen: View {
 
                 // Watch video button
                 if let videoUrlString = presenter.timetableItem.timetableItem.asset.videoUrl,
-                   let videoUrl = URL(string: videoUrlString) {
+                    let videoUrl = URL(string: videoUrlString)
+                {
                     Button {
                         showingURL = videoUrl
                     } label: {

--- a/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
+++ b/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
@@ -187,28 +187,6 @@ public struct TimetableDetailScreen: View {
                 .foregroundStyle(presenter.timetableItem.timetableItem.room.roomTheme.primaryColor)
 
             HStack(spacing: 12) {
-                // Watch video button
-                if let videoUrlString = presenter.timetableItem.timetableItem.asset.videoUrl,
-                   let videoUrl = URL(string: videoUrlString) {
-                    Button {
-                        showingURL = videoUrl
-                    } label: {
-                        HStack(spacing: 8) {
-                            AssetImages.icPlayCircle.swiftUIImage
-                                .resizable()
-                                .frame(width: 18, height: 18)
-                            Text(String(localized: "Video", bundle: .module))
-                                .font(Typography.labelLarge)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 16)
-                        .foregroundColor(AssetColors.surface.swiftUIColor)
-                        .background(presenter.timetableItem.timetableItem.room.roomTheme.primaryColor)
-                        .clipShape(RoundedRectangle(cornerRadius: 28))
-                    }
-                }
-
                 // Open slides button
                 if let slideUrlString = presenter.timetableItem.timetableItem.asset.slideUrl,
                    let slideUrl = URL(string: slideUrlString) {
@@ -220,6 +198,28 @@ public struct TimetableDetailScreen: View {
                                 .resizable()
                                 .frame(width: 18, height: 18)
                             Text(String(localized: "Slides", bundle: .module))
+                                .font(Typography.labelLarge)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 16)
+                        .foregroundColor(AssetColors.surface.swiftUIColor)
+                        .background(presenter.timetableItem.timetableItem.room.roomTheme.primaryColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 28))
+                    }
+                }
+
+                // Watch video button
+                if let videoUrlString = presenter.timetableItem.timetableItem.asset.videoUrl,
+                   let videoUrl = URL(string: videoUrlString) {
+                    Button {
+                        showingURL = videoUrl
+                    } label: {
+                        HStack(spacing: 8) {
+                            AssetImages.icPlayCircle.swiftUIImage
+                                .resizable()
+                                .frame(width: 18, height: 18)
+                            Text(String(localized: "Video", bundle: .module))
                                 .font(Typography.labelLarge)
                         }
                         .frame(maxWidth: .infinity)

--- a/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
+++ b/app-ios/Native/Sources/Feature/TimetableDetail/TimetableDetailScreen.swift
@@ -35,6 +35,10 @@ public struct TimetableDetailScreen: View {
                         .padding(.horizontal, 16)
                     targetAudience
                         .padding(16)
+                    if presenter.timetableItem.timetableItem.asset.isAvailable {
+                        archive
+                            .padding(16)
+                    }
 
                     Spacer().frame(height: 56)  // FAB space
                 }
@@ -176,6 +180,61 @@ public struct TimetableDetailScreen: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    var archive: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(String(localized: "Archive", bundle: .module))
+                .font(Typography.titleLarge)
+                .foregroundStyle(presenter.timetableItem.timetableItem.room.roomTheme.primaryColor)
+
+            HStack(spacing: 12) {
+                // Watch video button
+                if let videoUrlString = presenter.timetableItem.timetableItem.asset.videoUrl,
+                   let videoUrl = URL(string: videoUrlString) {
+                    Button {
+                        showingURL = videoUrl
+                    } label: {
+                        HStack(spacing: 8) {
+                            AssetImages.icPlayCircle.swiftUIImage
+                                .resizable()
+                                .frame(width: 18, height: 18)
+                            Text(String(localized: "Video", bundle: .module))
+                                .font(Typography.labelLarge)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 16)
+                        .foregroundColor(AssetColors.surface.swiftUIColor)
+                        .background(presenter.timetableItem.timetableItem.room.roomTheme.primaryColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 28))
+                    }
+                }
+
+                // Open slides button
+                if let slideUrlString = presenter.timetableItem.timetableItem.asset.slideUrl,
+                   let slideUrl = URL(string: slideUrlString) {
+                    Button {
+                        showingURL = slideUrl
+                    } label: {
+                        HStack(spacing: 8) {
+                            AssetImages.icDescription.swiftUIImage
+                                .resizable()
+                                .frame(width: 18, height: 18)
+                            Text(String(localized: "Slides", bundle: .module))
+                                .font(Typography.labelLarge)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 16)
+                        .foregroundColor(AssetColors.surface.swiftUIColor)
+                        .background(presenter.timetableItem.timetableItem.room.roomTheme.primaryColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 28))
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     var fabMenu: some View {
         VStack {
             Spacer()
@@ -231,50 +290,6 @@ public struct TimetableDetailScreen: View {
                                     AssetImages.icShare.swiftUIImage
 
                                     Text(String(localized: "Share link", bundle: .module))
-                                        .font(Typography.titleMedium)
-                                }
-                                .foregroundStyle(AssetColors.tertiaryContainer.swiftUIColor)
-                                .padding(.horizontal, 24)
-                                .padding(.vertical, 16)
-                                .background(
-                                    AssetColors.onTertiaryContainer.swiftUIColor, in: RoundedRectangle(cornerRadius: 28)
-                                )
-                            }
-                        }
-
-                        if let slideUrlString = presenter.timetableItem.timetableItem.asset.slideUrl,
-                            let slideUrl = URL(string: slideUrlString)
-                        {
-                            Button {
-                                showingURL = slideUrl
-                                isShowFabMenu = false
-                            } label: {
-                                HStack(spacing: 8) {
-                                    AssetImages.icDescription.swiftUIImage
-
-                                    Text(String(localized: "Open presentation slides", bundle: .module))
-                                        .font(Typography.titleMedium)
-                                }
-                                .foregroundStyle(AssetColors.tertiaryContainer.swiftUIColor)
-                                .padding(.horizontal, 24)
-                                .padding(.vertical, 16)
-                                .background(
-                                    AssetColors.onTertiaryContainer.swiftUIColor, in: RoundedRectangle(cornerRadius: 28)
-                                )
-                            }
-                        }
-
-                        if let videoUrlString = presenter.timetableItem.timetableItem.asset.videoUrl,
-                            let videoUrl = URL(string: videoUrlString)
-                        {
-                            Button {
-                                showingURL = videoUrl
-                                isShowFabMenu = false
-                            } label: {
-                                HStack(spacing: 8) {
-                                    AssetImages.icPlayCircle.swiftUIImage
-
-                                    Text(String(localized: "Watch video", bundle: .module))
                                         .font(Typography.titleMedium)
                                 }
                                 .foregroundStyle(AssetColors.tertiaryContainer.swiftUIColor)


### PR DESCRIPTION
## Issue
- close #617 

## Overview (Required)
This PR improves the session detail UI by relocating archive-related actions from the FAB menu to a dedicated archive section, following Material Design 3 guidelines.

### Changes:
Following Figma design specifications:
- **Added Archive section** below Target Audience section with video and slides buttons (moved from FAB menu)
- **Applied Room theme colors** to archive buttons for visual consistency
- **Updated button labels**: "Watch video" → "Video", "Open presentation slides" → "Slides"
- **Implemented conditional display** using `asset.isAvailable` (will show/hide based on content availability)

## Implementation Notes
- Archive section will display actual content when video/slide URLs are available from the backend
- Removed unused localization strings for the old button labels

## Links
- [Material Design 3 - FAB
guidelines](https://m3.material.io/components/floating-action-button/guidelines)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
**Note: The archive section is temporarily always visible with placeholder URLs for UI testing
  purposes. In production, it will only appear when video/slide URLs are available.**

Device | Before | After
:--: |:--: | :--:
iPhone 16 <br>Added archive section| <img width="300" src="https://github.com/user-attachments/assets/7fbc043d-f718-42a4-b3f8-f08faa3ed18b" /> | <img width="300" src="https://github.com/user-attachments/assets/4d8c3eac-834d-41d7-9f2a-6a78944e300a" />
iPhone 16 <br> FAB changes|<img width="300" src="https://github.com/user-attachments/assets/1204b16f-85aa-4c12-9f77-d54d912aff09" /> | <img width="300" src="https://github.com/user-attachments/assets/0f9c2205-fded-44ec-8ad6-776fd768ca7c" />
iPhone 16 <br> movie only|<img width="300" src="https://github.com/user-attachments/assets/f04bb4ac-2943-41fa-9575-4ea4cd891e54" /> | <img width="300" src="https://github.com/user-attachments/assets/8819e67d-6dd0-4d8d-86b4-f6df30f25110" />
iPad <br> Added archive section|<img width="300" src="https://github.com/user-attachments/assets/91457cf9-37c2-4396-bed3-2752684651c9" /> | <img width="300" src="https://github.com/user-attachments/assets/1156cb6e-a40e-40db-9603-1d7bd3e9acc9" />
iPad <br> FAB changes|<img width="300" src="https://github.com/user-attachments/assets/8f33e0bb-307f-430e-924b-e57953853e5a" /> | <img width="300" src="https://github.com/user-attachments/assets/a9fc62f0-f31f-4fa6-b9d2-cf44ced00836" />
iPad <br> movie only  | <img width="300" src="https://github.com/user-attachments/assets/4d64f975-cf1a-4819-8f6f-00d642e413fb" /> | <img width="300" src="https://github.com/user-attachments/assets/ebc7d0eb-4539-4441-bdc3-9353a9def3be" />



## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >

