### PR TITLE
Make date switching via timeline swipe more intuitive

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -167,8 +167,8 @@ fun TimetableScreen(
                         LaunchedEffect(selectedDay) {
                             pagerState.animateScrollToPage(selectedDay.tabIndex())
                         }
-                        LaunchedEffect(pagerState.targetPage) {
-                            onDaySelected(conferenceDays[pagerState.targetPage])
+                        LaunchedEffect(pagerState.settledPage) {
+                            onDaySelected(conferenceDays[pagerState.settledPage])
                         }
 
                         HorizontalPager(state = pagerState) { page ->


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Modified to use HorizontalPager for the list screen in timetables.
- Previous implementation switched dates based on drag distance, but this has been changed to page-based switching for improved intuitiveness.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/a8aa6886-3d51-4675-8456-5c5e25ec206e" width="300" > | <video src="https://github.com/user-attachments/assets/c20833e4-18d1-4dff-bc8b-ac82b9d1830f" width="300" >