### PR TITLE
[JVM] Implement share link tap behavior in session detail

### DIFF
--- a/app-shared/src/jvmMain/kotlin/io/github/droidkaigi/confsched/ExternalNavController.jvm.kt
+++ b/app-shared/src/jvmMain/kotlin/io/github/droidkaigi/confsched/ExternalNavController.jvm.kt
@@ -5,9 +5,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.ImageBitmap
 import io.github.droidkaigi.confsched.model.sessions.TimetableItem
 import java.awt.Desktop
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
 import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import javax.swing.JOptionPane
 import kotlin.time.Instant
 
 @Composable
@@ -51,7 +54,24 @@ class JvmExternalNavController : ExternalNavController {
     }
 
     override fun onShareClick(timetableItem: TimetableItem) {
-        TODO("Not yet implemented")
+        val text = "[${timetableItem.room.name.currentLangTitle}] ${timetableItem.formattedMonthAndDayString} " +
+            "${timetableItem.startsTimeString} - ${timetableItem.endsTimeString}\n" +
+            "${timetableItem.title.currentLangTitle}\n" +
+            timetableItem.url
+        try {
+            val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+            val selection = StringSelection(text)
+            clipboard.setContents(selection, selection)
+
+            JOptionPane.showMessageDialog(
+                null,
+                text,
+                "Copied to clipboard!",
+                JOptionPane.PLAIN_MESSAGE,
+            )
+        } catch (e: Exception) {
+            println("Failed to copy to clipboard: ${e.message}")
+        }
     }
 
     override fun onShareProfileCardClick(shareText: String, imageBitmap: ImageBitmap) {


### PR DESCRIPTION
## Issue
- close #166

## Overview (Required)
- Implements `onShareClick` function of `JvmExternalNavController`.
   - There's no general function to share text, so copied to clipboard.
   - And show message dialog using `JOptionPane` simply.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="https://github.com/user-attachments/assets/9a7f4401-8ea2-41a9-9eef-d3defd84e87d" width="300" >