### PR TITLE
Enabled trailing comma when IDE format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,5 @@ tab_width = 4
 ij_kotlin_name_count_to_use_star_import = 999
 ij_kotlin_name_count_to_use_star_import_for_members = 999
 charset = utf-8
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- I want to apply trailing commas when formatting code in Android Studio.
  - Spotless warnings should be formatted in the IDE.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
