### PR TITLE
Fixed LicensesScreen displayed as a standalone screen.

### DIFF
--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/AboutNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/AboutNavEntry.kt
@@ -9,6 +9,7 @@ import io.github.droidkaigi.confsched.about.LicensesScreenRoot
 import io.github.droidkaigi.confsched.about.rememberAboutScreenContextRetained
 import io.github.droidkaigi.confsched.about.rememberLicensesScreenContextRetained
 import io.github.droidkaigi.confsched.model.about.AboutItem
+import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyDetailPaneMetaData
 import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyListPaneMetaData
 import io.github.droidkaigi.confsched.navkey.AboutNavKey
 import io.github.droidkaigi.confsched.navkey.LicensesNavKey
@@ -43,7 +44,9 @@ context(appGraph: AppGraph)
 fun EntryProviderBuilder<NavKey>.licensesEntry(
     onBackClick: () -> Unit,
 ) {
-    entry<LicensesNavKey> {
+    entry<LicensesNavKey>(
+        metadata = listDetailSceneStrategyDetailPaneMetaData(),
+    ) {
         with(rememberLicensesScreenContextRetained()) {
             LicensesScreenRoot(
                 onBackClick = onBackClick,


### PR DESCRIPTION
## Issue
- close #634

## Overview (Required)
- I changed it so that the license screen opens in Adaptive mode, just like other screens.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/2e6b703d-703f-4f02-ac48-12acf9c4533c" width="300" /> | <img src="https://github.com/user-attachments/assets/9db6f2d4-9509-4f1f-bdd3-51e1dbb078e2" width="300" />

## Movie (Optional)
<video src="https://github.com/user-attachments/assets/8f34d68e-4c02-4845-81d8-13b473214242" width="300" >
