### PR TITLE
rename profilePresenter to profileScreenPresenter & {featureName}UiState to {featureName}ScreenUiState

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -29,7 +29,7 @@ const val EventMapScreenTestTag = "EventMapScreenTestTag"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EventMapScreen(
-    uiState: EventMapUiState,
+    uiState: EventMapScreenUiState,
     onSelectFloor: (FloorLevel) -> Unit,
     onClickReadMore: (url: String) -> Unit,
     modifier: Modifier = Modifier,
@@ -69,7 +69,7 @@ fun EventMapScreen(
 private fun EventMapScreenPreview() {
     KaigiPreviewContainer {
         EventMapScreen(
-            uiState = EventMapUiState(
+            uiState = EventMapScreenUiState(
                 events = EventMapEvent.Companion.fakes(),
                 selectedFloor = FloorLevel.Ground,
             ),

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
@@ -32,7 +32,7 @@ fun eventMapScreenPresenter(
         }
     }
 
-    EventMapUiState(
+    EventMapScreenUiState(
         events = events,
         selectedFloor = selectedFloor,
     )

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenUiState.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenUiState.kt
@@ -4,7 +4,7 @@ import io.github.droidkaigi.confsched.model.eventmap.EventMapEvent
 import io.github.droidkaigi.confsched.model.eventmap.FloorLevel
 import kotlinx.collections.immutable.PersistentList
 
-data class EventMapUiState(
+data class EventMapScreenUiState(
     val events: PersistentList<EventMapEvent>,
     val selectedFloor: FloorLevel,
 )

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMap.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMap.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.droidkaigiui.extension.enableMouseDragScroll
-import io.github.droidkaigi.confsched.eventmap.EventMapUiState
+import io.github.droidkaigi.confsched.eventmap.EventMapScreenUiState
 import io.github.droidkaigi.confsched.eventmap.EventmapRes
 import io.github.droidkaigi.confsched.eventmap.event_map_description
 import io.github.droidkaigi.confsched.model.eventmap.FloorLevel
@@ -27,7 +27,7 @@ const val EventMapItemTestTag = "EventMapItemTestTag:"
 
 @Composable
 fun EventMap(
-    uiState: EventMapUiState,
+    uiState: EventMapScreenUiState,
     listState: LazyListState,
     onSelectFloor: (FloorLevel) -> Unit,
     onClickReadMore: (url: String) -> Unit,

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileCardScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileCardScreen.kt
@@ -67,7 +67,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ProfileCardScreen(
-    uiState: ProfileUiState.Card,
+    uiState: ProfileScreenUiState.Card,
     onEditClick: () -> Unit,
     onShareClick: (ImageBitmap) -> Unit,
     modifier: Modifier = Modifier,
@@ -197,7 +197,7 @@ fun ProfileCardScreen(
 private fun ProfileCardScreenPreview() {
     KaigiPreviewContainer {
         ProfileCardScreen(
-            uiState = ProfileUiState.Card(
+            uiState = ProfileScreenUiState.Card(
                 profile = Profile(
                     nickName = "DroidKaigi",
                     occupation = "Software Engineer",

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenPresenter.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenPresenter.kt
@@ -14,7 +14,7 @@ import soil.query.compose.rememberMutation
 
 @Composable
 context(screenContext: ProfileScreenContext)
-fun profilePresenter(
+fun profileScreenPresenter(
     eventFlow: EventFlow<ProfileScreenEvent>,
     profileWithImages: ProfileWithImages,
 ): ProfileUiState = providePresenterDefaults {

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenPresenter.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenPresenter.kt
@@ -17,7 +17,7 @@ context(screenContext: ProfileScreenContext)
 fun profileScreenPresenter(
     eventFlow: EventFlow<ProfileScreenEvent>,
     profileWithImages: ProfileWithImages,
-): ProfileUiState = providePresenterDefaults {
+): ProfileScreenUiState = providePresenterDefaults {
     val isAllowedToShowCard = profileWithImages.profile != null &&
         profileWithImages.profileImageByteArray != null &&
         profileWithImages.qrImageByteArray != null
@@ -43,12 +43,12 @@ fun profileScreenPresenter(
     }
 
     if (!isAllowedToShowCard || isInEditMode) {
-        ProfileUiState.Edit(
+        ProfileScreenUiState.Edit(
             baseProfile = profileWithImages.profile,
             canBackToCardScreen = isAllowedToShowCard,
         )
     } else {
-        ProfileUiState.Card(
+        ProfileScreenUiState.Card(
             profile = requireNotNull(profileWithImages.profile),
             profileImageBitmap = requireNotNull(profileWithImages.profileImageByteArray).decodeToImageBitmap(),
             qrImageBitmap = requireNotNull(profileWithImages.qrImageByteArray).decodeToImageBitmap(),

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenRoot.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenRoot.kt
@@ -26,7 +26,7 @@ fun ProfileScreenRoot(
     ) { profileWithImageBitmaps ->
         val eventFlow = rememberEventFlow<ProfileScreenEvent>()
 
-        val uiState = profilePresenter(
+        val uiState = profileScreenPresenter(
             eventFlow = eventFlow,
             profileWithImages = profileWithImageBitmaps,
         )

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenRoot.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenRoot.kt
@@ -32,7 +32,7 @@ fun ProfileScreenRoot(
         )
 
         when (uiState) {
-            is ProfileUiState.Card -> {
+            is ProfileScreenUiState.Card -> {
                 val shareText = stringResource(ProfileRes.string.share_description)
 
                 ProfileCardScreen(
@@ -44,7 +44,7 @@ fun ProfileScreenRoot(
                 )
             }
 
-            is ProfileUiState.Edit -> {
+            is ProfileScreenUiState.Edit -> {
                 BackHandler(enabled = uiState.canBackToCardScreen) {
                     eventFlow.tryEmit(ProfileScreenEvent.ExitEditMode)
                 }

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenUiState.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileScreenUiState.kt
@@ -3,15 +3,15 @@ package io.github.confsched.profile
 import androidx.compose.ui.graphics.ImageBitmap
 import io.github.droidkaigi.confsched.model.profile.Profile
 
-sealed interface ProfileUiState {
+sealed interface ProfileScreenUiState {
     data class Card(
         val profile: Profile,
         val profileImageBitmap: ImageBitmap,
         val qrImageBitmap: ImageBitmap,
-    ) : ProfileUiState
+    ) : ProfileScreenUiState
 
     data class Edit(
         val baseProfile: Profile?,
         val canBackToCardScreen: Boolean,
-    ) : ProfileUiState
+    ) : ProfileScreenUiState
 }

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/components/FlippableProfileCard.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import io.github.confsched.profile.ProfileUiState
+import io.github.confsched.profile.ProfileScreenUiState
 import io.github.confsched.profile.hologramaticEffect
 import io.github.confsched.profile.tiltEffect
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
@@ -34,7 +34,7 @@ private enum class FlipState { Initial, Animating, Default }
 
 @Composable
 fun FlippableProfileCard(
-    uiState: ProfileUiState.Card,
+    uiState: ProfileScreenUiState.Card,
     modifier: Modifier = Modifier,
 ) {
     var flipState by remember { mutableStateOf(FlipState.Initial) }
@@ -81,7 +81,7 @@ fun FlippableProfileCard(
 
 @Composable
 private fun ProfileCard(
-    uiState: ProfileUiState.Card,
+    uiState: ProfileScreenUiState.Card,
     rotation: Float,
     isFlipped: Boolean,
     onFlippedChange: (Boolean) -> Unit,
@@ -142,7 +142,7 @@ private fun ProfileCard(
 private fun FlippableProfileCardPreview() {
     KaigiPreviewContainer {
         FlippableProfileCard(
-            uiState = ProfileUiState.Card(
+            uiState = ProfileScreenUiState.Card(
                 profile = Profile(
                     nickName = "DroidKaigi",
                     occupation = "Software Engineer",

--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreen.kt
@@ -29,7 +29,7 @@ const val SettingsScreenLazyColumnTestTag = "SettingsScreen"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    uiState: SettingsUiState,
+    uiState: SettingsScreenUiState,
     onBackClick: () -> Unit,
     onSelectUseFontFamily: (KaigiFontFamily) -> Unit,
     modifier: Modifier = Modifier,
@@ -69,7 +69,7 @@ fun SettingsScreen(
 fun SettingsScreenPreview() {
     KaigiPreviewContainer {
         SettingsScreen(
-            uiState = SettingsUiState(
+            uiState = SettingsScreenUiState(
                 useKaigiFontFamily = KaigiFontFamily.ChangoRegular,
             ),
             onBackClick = {},

--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenPresenter.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenPresenter.kt
@@ -12,7 +12,7 @@ context(screenContext: SettingsScreenContext)
 fun settingsScreenPresenter(
     eventFlow: EventFlow<SettingsScreenEvent>,
     settings: Settings,
-): SettingsUiState = providePresenterDefaults {
+): SettingsScreenUiState = providePresenterDefaults {
     val settingsMutation = rememberMutation(screenContext.settingsMutationKey)
 
     EventEffect(eventFlow) { event ->
@@ -23,7 +23,7 @@ fun settingsScreenPresenter(
         }
     }
 
-    SettingsUiState(
+    SettingsScreenUiState(
         useKaigiFontFamily = settings.useKaigiFontFamily,
     )
 }

--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenUiState.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenUiState.kt
@@ -2,6 +2,6 @@ package io.github.droidkaigi.confsched.settings
 
 import io.github.droidkaigi.confsched.model.settings.KaigiFontFamily
 
-data class SettingsUiState(
+data class SettingsScreenUiState(
     val useKaigiFontFamily: KaigiFontFamily,
 )

--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/section/SettingsAccessibility.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/section/SettingsAccessibility.kt
@@ -21,7 +21,7 @@ import io.github.droidkaigi.confsched.designsystem.theme.robotoMediumFontFamily
 import io.github.droidkaigi.confsched.designsystem.theme.robotoRegularFontFamily
 import io.github.droidkaigi.confsched.model.settings.KaigiFontFamily
 import io.github.droidkaigi.confsched.settings.SettingsRes
-import io.github.droidkaigi.confsched.settings.SettingsUiState
+import io.github.droidkaigi.confsched.settings.SettingsScreenUiState
 import io.github.droidkaigi.confsched.settings.component.SettingsItemRow
 import io.github.droidkaigi.confsched.settings.ic_brand_family
 import io.github.droidkaigi.confsched.settings.section_item_title_font
@@ -34,7 +34,7 @@ const val SettingsAccessibilityUseFontFamilySelectableItemColumnTestTagPrefix =
 
 fun LazyListScope.accessibility(
     modifier: Modifier = Modifier,
-    uiState: SettingsUiState,
+    uiState: SettingsScreenUiState,
     onSelectUseFontFamily: (KaigiFontFamily) -> Unit,
 ) {
     item {


### PR DESCRIPTION
## Issue
- close #633 

## Overview (Required)
- rename `profilePresenter` to `profileScreenPresenter`.
- The following `UiState` have been renamed: 
  - `EventMapUiState` to `EventMapScreenUiState`
  - `ProfileUiState` to `ProfileScreenUiState`
  - `SettingsUiState` to `SettingsScreenUiState`

## Screenshot (Optional if screenshot test is present or unrelated to UI)

### profile
ProfileEditScreen | ProfileCardScreen
--- | ---
<img width="300" src="https://github.com/user-attachments/assets/2d60473d-7a0d-42af-99cb-eb07328404b5" /> | <img width="300" src="https://github.com/user-attachments/assets/f46d2260-98bb-4dc8-81f4-7d50119c1b15" />

### eventMap
<img width="300" src="https://github.com/user-attachments/assets/3876ebd4-1505-47e7-bd97-e1b0a3759a50" />

### settings
<img width="300" src="https://github.com/user-attachments/assets/0b0a957a-f9f5-4ebc-ae8f-02be3d61faa6" />
