### PR TITLE
Change image loading indicator style

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/AsyncImage.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/AsyncImage.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -25,7 +25,7 @@ fun SubcomposeAsyncImage(
     contentScale: ContentScale = ContentScale.Fit,
     modifier: Modifier = Modifier,
     loading: @Composable (SubcomposeAsyncImageScope.(State.Loading) -> Unit)? = {
-        CircularWavyProgressIndicator(
+        LoadingIndicator(
             modifier = Modifier
                 .padding(4.dp)
                 .wrapContentSize()


### PR DESCRIPTION
## Issue
- close #641

## Overview (Required)
- Changed default image loading indicator from `CircularWavyProgressIndicator` to `LoadingIndicator`

## Links
- https://m3.material.io/components/loading-indicator/overview#ec97d10e-5da9-4359-850e-e98af92db394


## Movie (Optional)
| Before | After |
| :--: | :--: |
| <video src="https://github.com/user-attachments/assets/80ece970-3207-4f55-8f58-4fccde82ca8f"> | <video src="https://github.com/user-attachments/assets/f08f535f-67dd-4d28-b8c9-eecabe8afed3"> |
