### PR TITLE
Fix back navigation behavior when tapping a list item in About Screen.

### DIFF
--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -3,7 +3,9 @@ package io.github.droidkaigi.confsched
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
 import dev.chrisbanes.haze.hazeSource
@@ -31,13 +33,13 @@ import io.github.droidkaigi.confsched.navigation.rememberNavBackStack
 import io.github.droidkaigi.confsched.navigation.sceneStrategy
 import io.github.droidkaigi.confsched.navkey.AboutItemNavKey
 import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.ContributorsNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.LicensesNavKey
 import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.SettingsNavKey
 import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.SponsorsNavKey
 import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.StaffNavKey
 import io.github.droidkaigi.confsched.navkey.AboutNavKey
 import io.github.droidkaigi.confsched.navkey.EventMapNavKey
 import io.github.droidkaigi.confsched.navkey.FavoritesNavKey
-import io.github.droidkaigi.confsched.navkey.LicensesNavKey
 import io.github.droidkaigi.confsched.navkey.ProfileNavKey
 import io.github.droidkaigi.confsched.navkey.SearchNavKey
 import io.github.droidkaigi.confsched.navkey.TimetableItemDetailNavKey
@@ -86,10 +88,7 @@ actual fun KaigiAppUi() {
                     onLinkClick = externalNavController::navigate,
                     onSearchClick = { backStack.add(SearchNavKey) },
                     onTimetableItemClick = {
-                        if (backStack.lastOrNull() is TimetableItemDetailNavKey) {
-                            backStack.removeLastOrNull()
-                        }
-                        backStack.add(TimetableItemDetailNavKey(it))
+                        backStack.addSingleTop(TimetableItemDetailNavKey(it))
                     },
                     timeTableEntryMetadata = NavDisplay.topLevelTransition(),
                 )
@@ -110,10 +109,7 @@ actual fun KaigiAppUi() {
                 )
                 favoritesEntry(
                     onTimetableItemClick = {
-                        if (backStack.lastOrNull() is TimetableItemDetailNavKey) {
-                            backStack.removeLastOrNull()
-                        }
-                        backStack.add(TimetableItemDetailNavKey(it))
+                        backStack.addSingleTop(TimetableItemDetailNavKey(it))
                     },
                     metadata = NavDisplay.topLevelTransition(),
                 )
@@ -129,13 +125,6 @@ actual fun KaigiAppUi() {
                             "https://portal.droidkaigi.jp/en"
                         }
 
-                        fun navigateToAboutItem(navKey: AboutItemNavKey) {
-                            if (backStack.lastOrNull() is AboutItemNavKey) {
-                                backStack.removeLastOrNull()
-                            }
-                            backStack.add(navKey)
-                        }
-
                         when (item) {
                             AboutItem.Map -> {
                                 externalNavController.navigate(
@@ -143,16 +132,16 @@ actual fun KaigiAppUi() {
                                 )
                             }
 
-                            AboutItem.Contributors -> navigateToAboutItem(ContributorsNavKey)
-                            AboutItem.Sponsors -> navigateToAboutItem(SponsorsNavKey)
-                            AboutItem.Staff -> navigateToAboutItem(StaffNavKey)
+                            AboutItem.Contributors -> backStack.addSingleTop<AboutItemNavKey>(ContributorsNavKey)
+                            AboutItem.Sponsors -> backStack.addSingleTop<AboutItemNavKey>(SponsorsNavKey)
+                            AboutItem.Staff -> backStack.addSingleTop<AboutItemNavKey>(StaffNavKey)
                             AboutItem.CodeOfConduct -> {
                                 externalNavController.navigate(
                                     url = "$portalBaseUrl/about/code-of-conduct",
                                 )
                             }
 
-                            AboutItem.License -> backStack.add(LicensesNavKey)
+                            AboutItem.License -> backStack.addSingleTop<AboutItemNavKey>(LicensesNavKey)
 
                             AboutItem.PrivacyPolicy -> {
                                 externalNavController.navigate(
@@ -160,7 +149,7 @@ actual fun KaigiAppUi() {
                                 )
                             }
 
-                            AboutItem.Settings -> navigateToAboutItem(SettingsNavKey)
+                            AboutItem.Settings -> backStack.addSingleTop<AboutItemNavKey>(SettingsNavKey)
                             AboutItem.Youtube -> {
                                 externalNavController.navigate(
                                     url = "https://www.youtube.com/c/DroidKaigi",
@@ -204,4 +193,11 @@ private fun NavDisplay.topLevelTransition() = transitionSpec {
     materialFadeIn() togetherWith materialFadeOut()
 } + NavDisplay.predictivePopTransitionSpec {
     materialFadeIn() togetherWith materialFadeOut()
+}
+
+inline fun <reified Key : NavKey> SnapshotStateList<NavKey>.addSingleTop(navKey: Key) {
+    if (this.lastOrNull() is Key) {
+        removeLastOrNull()
+    }
+    add(navKey)
 }

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/KaigiAppUi.androidJvm.kt
@@ -29,16 +29,17 @@ import io.github.droidkaigi.confsched.navigation.materialFadeIn
 import io.github.droidkaigi.confsched.navigation.materialFadeOut
 import io.github.droidkaigi.confsched.navigation.rememberNavBackStack
 import io.github.droidkaigi.confsched.navigation.sceneStrategy
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.ContributorsNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.SettingsNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.SponsorsNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.StaffNavKey
 import io.github.droidkaigi.confsched.navkey.AboutNavKey
-import io.github.droidkaigi.confsched.navkey.ContributorsNavKey
 import io.github.droidkaigi.confsched.navkey.EventMapNavKey
 import io.github.droidkaigi.confsched.navkey.FavoritesNavKey
 import io.github.droidkaigi.confsched.navkey.LicensesNavKey
 import io.github.droidkaigi.confsched.navkey.ProfileNavKey
 import io.github.droidkaigi.confsched.navkey.SearchNavKey
-import io.github.droidkaigi.confsched.navkey.SettingsNavKey
-import io.github.droidkaigi.confsched.navkey.SponsorsNavKey
-import io.github.droidkaigi.confsched.navkey.StaffNavKey
 import io.github.droidkaigi.confsched.navkey.TimetableItemDetailNavKey
 import io.github.droidkaigi.confsched.navkey.TimetableNavKey
 
@@ -127,6 +128,14 @@ actual fun KaigiAppUi() {
                         } else {
                             "https://portal.droidkaigi.jp/en"
                         }
+
+                        fun navigateToAboutItem(navKey: AboutItemNavKey) {
+                            if (backStack.lastOrNull() is AboutItemNavKey) {
+                                backStack.removeLastOrNull()
+                            }
+                            backStack.add(navKey)
+                        }
+
                         when (item) {
                             AboutItem.Map -> {
                                 externalNavController.navigate(
@@ -134,9 +143,9 @@ actual fun KaigiAppUi() {
                                 )
                             }
 
-                            AboutItem.Contributors -> backStack.add(ContributorsNavKey)
-                            AboutItem.Sponsors -> backStack.add(SponsorsNavKey)
-                            AboutItem.Staff -> backStack.add(StaffNavKey)
+                            AboutItem.Contributors -> navigateToAboutItem(ContributorsNavKey)
+                            AboutItem.Sponsors -> navigateToAboutItem(SponsorsNavKey)
+                            AboutItem.Staff -> navigateToAboutItem(StaffNavKey)
                             AboutItem.CodeOfConduct -> {
                                 externalNavController.navigate(
                                     url = "$portalBaseUrl/about/code-of-conduct",
@@ -151,7 +160,7 @@ actual fun KaigiAppUi() {
                                 )
                             }
 
-                            AboutItem.Settings -> backStack.add(SettingsNavKey)
+                            AboutItem.Settings -> navigateToAboutItem(SettingsNavKey)
                             AboutItem.Youtube -> {
                                 externalNavController.navigate(
                                     url = "https://www.youtube.com/c/DroidKaigi",

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/AboutNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/AboutNavEntry.kt
@@ -11,8 +11,8 @@ import io.github.droidkaigi.confsched.about.rememberLicensesScreenContextRetaine
 import io.github.droidkaigi.confsched.model.about.AboutItem
 import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyDetailPaneMetaData
 import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyListPaneMetaData
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.LicensesNavKey
 import io.github.droidkaigi.confsched.navkey.AboutNavKey
-import io.github.droidkaigi.confsched.navkey.LicensesNavKey
 
 context(appGraph: AppGraph)
 fun EntryProviderBuilder<NavKey>.aboutEntries(

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/ContributorsNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/ContributorsNavEntry.kt
@@ -7,7 +7,7 @@ import io.github.droidkaigi.confsched.AppGraph
 import io.github.droidkaigi.confsched.contributors.ContributorsScreenRoot
 import io.github.droidkaigi.confsched.contributors.rememberContributorsScreenContextRetained
 import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyDetailPaneMetaData
-import io.github.droidkaigi.confsched.navkey.ContributorsNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.ContributorsNavKey
 
 context(appGraph: AppGraph)
 fun EntryProviderBuilder<NavKey>.contributorsEntry(

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SettingsNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SettingsNavEntry.kt
@@ -5,7 +5,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
 import io.github.droidkaigi.confsched.AppGraph
 import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyDetailPaneMetaData
-import io.github.droidkaigi.confsched.navkey.SettingsNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.SettingsNavKey
 import io.github.droidkaigi.confsched.settings.SettingsScreenRoot
 import io.github.droidkaigi.confsched.settings.rememberSettingsScreenContextRetained
 

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SponsorsNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/SponsorsNavEntry.kt
@@ -5,7 +5,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
 import io.github.droidkaigi.confsched.AppGraph
 import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyDetailPaneMetaData
-import io.github.droidkaigi.confsched.navkey.SponsorsNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.SponsorsNavKey
 import io.github.droidkaigi.confsched.sponsors.SponsorScreenRoot
 import io.github.droidkaigi.confsched.sponsors.rememberSponsorsScreenContextRetained
 

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/StaffNavEntry.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/naventry/StaffNavEntry.kt
@@ -5,7 +5,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
 import io.github.droidkaigi.confsched.AppGraph
 import io.github.droidkaigi.confsched.navigation.listDetailSceneStrategyDetailPaneMetaData
-import io.github.droidkaigi.confsched.navkey.StaffNavKey
+import io.github.droidkaigi.confsched.navkey.AboutItemNavKey.StaffNavKey
 import io.github.droidkaigi.confsched.staff.StaffScreenRoot
 import io.github.droidkaigi.confsched.staff.rememberStaffScreenContextRetained
 

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navkey/AboutNavKey.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navkey/AboutNavKey.kt
@@ -8,3 +8,14 @@ data object AboutNavKey : NavKey
 
 @Serializable
 data object LicensesNavKey : NavKey
+
+sealed interface AboutItemNavKey : NavKey {
+    @Serializable
+    data object ContributorsNavKey : AboutItemNavKey
+    @Serializable
+    data object SettingsNavKey : AboutItemNavKey
+    @Serializable
+    data object StaffNavKey : AboutItemNavKey
+    @Serializable
+    data object SponsorsNavKey : AboutItemNavKey
+}

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navkey/AboutNavKey.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navkey/AboutNavKey.kt
@@ -6,12 +6,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object AboutNavKey : NavKey
 
-@Serializable
-data object LicensesNavKey : NavKey
-
 sealed interface AboutItemNavKey : NavKey {
     @Serializable
     data object ContributorsNavKey : AboutItemNavKey
+
+    @Serializable
+    data object LicensesNavKey : AboutItemNavKey
 
     @Serializable
     data object SettingsNavKey : AboutItemNavKey

--- a/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navkey/AboutNavKey.kt
+++ b/app-shared/src/androidJvmMain/kotlin/io/github/droidkaigi/confsched/navkey/AboutNavKey.kt
@@ -12,10 +12,13 @@ data object LicensesNavKey : NavKey
 sealed interface AboutItemNavKey : NavKey {
     @Serializable
     data object ContributorsNavKey : AboutItemNavKey
+
     @Serializable
     data object SettingsNavKey : AboutItemNavKey
+
     @Serializable
     data object StaffNavKey : AboutItemNavKey
+
     @Serializable
     data object SponsorsNavKey : AboutItemNavKey
 }


### PR DESCRIPTION
## Issue
- close #644 

## Overview (Required)
- Fix back navigation behavior when tapping a list item in the About Screen.
  - Currently, the items in the “About” screen opened in the right pane reappear when you tap another item with the same specification and then press the back key.
  - Therefore, fixed to pop the NavKey from the back stack when tapping the About Screen Items if another item with the same specification exists on the back stack. 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
![record-250911234424](https://github.com/user-attachments/assets/94ae7955-77d3-4605-8c7a-c90bd64f369c) | ![record-250911234045](https://github.com/user-attachments/assets/f687b4d7-1ff9-444a-9a01-b6822d60a6b5)






