### PR TITLE
feat(test): add basic timetable screen test

### DIFF
--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/sessions/TimetableScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/sessions/TimetableScreenRobot.kt
@@ -1,21 +1,36 @@
 package io.github.droidkaigi.confsched.testing.robot.sessions
 
 import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
 import dev.zacsweers.metro.Inject
 import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultErrorFallbackContentRetryTestTag
 import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultErrorFallbackContentTestTag
 import io.github.droidkaigi.confsched.droidkaigiui.architecture.DefaultSuspenseFallbackContentTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardBookmarkButtonTestTag
+import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardTestTag
 import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableListTestTag
 import io.github.droidkaigi.confsched.model.core.DroidKaigi2025Day
+import io.github.droidkaigi.confsched.sessions.TimetableConferenceDayTestTag
+import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenLazyColumnTestTag
 import io.github.droidkaigi.confsched.sessions.TimetableScreenContext
 import io.github.droidkaigi.confsched.sessions.TimetableScreenRoot
+import io.github.droidkaigi.confsched.sessions.TimetableScreenTestTag
+import io.github.droidkaigi.confsched.sessions.components.TimetableGridItemTestTag
+import io.github.droidkaigi.confsched.sessions.components.TimetableUiTypeChangeTestTag
+import io.github.droidkaigi.confsched.sessions.grid.TimetableGridTestTag
 import io.github.droidkaigi.confsched.testing.compose.TestDefaultsProvider
 import io.github.droidkaigi.confsched.testing.robot.core.CaptureScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.core.DefaultCaptureScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.core.DefaultWaitRobot
 import io.github.droidkaigi.confsched.testing.robot.core.WaitRobot
+import io.github.droidkaigi.confsched.testing.util.onAllNodesWithTag
 import kotlinx.coroutines.test.TestDispatcher
 
 @Inject
@@ -55,7 +70,11 @@ class TimetableScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     fun clickFirstSessionBookmark() {
-        // TODO
+        composeUiTest
+            .onAllNodesWithTag(TimetableItemCardBookmarkButtonTestTag)
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
     }
 
     context(composeUiTest: ComposeUiTest)
@@ -65,17 +84,86 @@ class TimetableScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     fun checkTimetableListItemsDisplayed() {
-        // TODO
+        composeUiTest
+            .onNodeWithTag(TimetableListTestTag)
+            .assertIsDisplayed()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun checkTimetableTabSelected(day: DroidKaigi2025Day) {
-        // TODO
+        composeUiTest
+            .onNodeWithTag(TimetableConferenceDayTestTag.plus(day.ordinal))
+            .assertIsSelected()
     }
 
     context(composeUiTest: ComposeUiTest)
     fun clickFirstSession() {
-        // TODO
+        composeUiTest
+            .onAllNodesWithTag(TimetableItemCardTestTag)
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkClickedItemsExists() {
+        // TODO: Implement this method to verify that clicked items exist
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun scrollTimetable() {
+        composeUiTest
+            .onNodeWithTag(TimetableScreenTestTag)
+            .performTouchInput {
+                swipeUp()
+            }
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableListFirstItemNotDisplayed() {
+        composeUiTest
+            .onAllNodesWithTag(TimetableItemCardTestTag)
+            .onFirst()
+            .assertIsNotDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickTimetableTab(day: DroidKaigi2025Day) {
+        composeUiTest
+            .onNodeWithTag(TimetableConferenceDayTestTag.plus(day.ordinal))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun clickTimetableUiTypeChangeButton() {
+        composeUiTest
+            .onNodeWithTag(TimetableUiTypeChangeTestTag)
+            .performClick()
+        waitUntilIdle()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableGridDisplayed() {
+        composeUiTest
+            .onNodeWithTag(TimetableGridTestTag)
+            .assertIsDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableGridItemsDisplayed() {
+        composeUiTest
+            .onAllNodesWithTag(TimetableGridItemTestTag)
+            .onFirst()
+            .assertIsDisplayed()
+    }
+
+    context(composeUiTest: ComposeUiTest)
+    fun checkTimetableGridFirstItemNotDisplayed() {
+        composeUiTest
+            .onAllNodesWithTag(TimetableGridItemTestTag)
+            .onFirst()
+            .assertIsNotDisplayed()
     }
 
     context(composeUiTest: ComposeUiTest)

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/sessions/TimetableScreenRobot.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/robot/sessions/TimetableScreenRobot.kt
@@ -17,8 +17,8 @@ import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardBook
 import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableItemCardTestTag
 import io.github.droidkaigi.confsched.droidkaigiui.session.TimetableListTestTag
 import io.github.droidkaigi.confsched.model.core.DroidKaigi2025Day
+import io.github.droidkaigi.confsched.model.sessions.TimetableItemId
 import io.github.droidkaigi.confsched.sessions.TimetableConferenceDayTestTag
-import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenLazyColumnTestTag
 import io.github.droidkaigi.confsched.sessions.TimetableScreenContext
 import io.github.droidkaigi.confsched.sessions.TimetableScreenRoot
 import io.github.droidkaigi.confsched.sessions.TimetableScreenTestTag
@@ -32,6 +32,7 @@ import io.github.droidkaigi.confsched.testing.robot.core.DefaultWaitRobot
 import io.github.droidkaigi.confsched.testing.robot.core.WaitRobot
 import io.github.droidkaigi.confsched.testing.util.onAllNodesWithTag
 import kotlinx.coroutines.test.TestDispatcher
+import kotlin.test.assertTrue
 
 @Inject
 class TimetableScreenRobot(
@@ -43,6 +44,7 @@ class TimetableScreenRobot(
 ) : TimetableServerRobot by timetableServerRobot,
     CaptureScreenRobot by captureScreenRobot,
     WaitRobot by waitRobot {
+    val clickedItems = mutableSetOf<TimetableItemId>()
 
     context(composeUiTest: ComposeUiTest)
     fun setupTimetableScreenContent() {
@@ -51,7 +53,9 @@ class TimetableScreenRobot(
                 TestDefaultsProvider(testDispatcher) {
                     TimetableScreenRoot(
                         onSearchClick = {},
-                        onTimetableItemClick = {},
+                        onTimetableItemClick = {
+                            clickedItems.add(it)
+                        },
                     )
                 }
             }
@@ -107,7 +111,7 @@ class TimetableScreenRobot(
 
     context(composeUiTest: ComposeUiTest)
     fun checkClickedItemsExists() {
-        // TODO: Implement this method to verify that clicked items exist
+        assertTrue(clickedItems.isNotEmpty())
     }
 
     context(composeUiTest: ComposeUiTest)

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.common.compose.rememberXrEnvironment
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
@@ -54,6 +55,9 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentMap
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.time.Duration.Companion.hours
+
+const val TimetableScreenTestTag = "TimetableScreenTestTag"
+const val TimetableConferenceDayTestTag = "TimetableConferenceDayTestTag"
 
 @Composable
 fun TimetableScreen(
@@ -100,7 +104,9 @@ fun TimetableScreen(
         },
         containerColor = if (isFullSpace) MaterialTheme.colorScheme.surface else Color.Transparent,
         contentWindowInsets = WindowInsets(),
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(TimetableScreenTestTag),
     ) { paddingValues ->
         if (!isFullSpace) {
             TimetableBackground()
@@ -131,7 +137,9 @@ fun TimetableScreen(
                                     inactiveContainerColor = MaterialTheme.colorScheme.surface,
                                 ),
                                 selected = selectedDay == droidKaigi2025Day,
-                                modifier = Modifier.width(TimetableDefaults.dayTabWidth),
+                                modifier = Modifier
+                                    .width(TimetableDefaults.dayTabWidth)
+                                    .testTag(TimetableConferenceDayTestTag.plus(droidKaigi2025Day.ordinal)),
                             ) {
                                 Text(droidKaigi2025Day.monthAndDay())
                             }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableGridItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -50,6 +51,8 @@ import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.time.Duration.Companion.minutes
+
+const val TimetableGridItemTestTag = "TimetableGridItem"
 
 @Composable
 fun TimetableGridItem(
@@ -104,7 +107,8 @@ fun TimetableGridItem(
                             TimetableGridItemDefaults.contentPadding / 2
                         }
                     },
-                ),
+                )
+                .testTag(TimetableGridItemTestTag),
         ) {
             Column(
                 modifier = Modifier.weight(1f),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
@@ -64,7 +64,7 @@ fun TimetableTopAppBar(
             IconButton(
                 onClick = onUiTypeChangeClick,
                 shapes = IconButtonDefaults.shapes(),
-                modifier = Modifier.testTag(TimetableUiTypeChangeTestTag)
+                modifier = Modifier.testTag(TimetableUiTypeChangeTestTag),
             ) {
                 val iconRes = when (timetableUiType) {
                     TimetableUiType.List -> SessionsRes.drawable.ic_view_grid

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/components/TimetableTopAppBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import io.github.droidkaigi.confsched.common.compose.rememberXrEnvironment
 import io.github.droidkaigi.confsched.droidkaigiui.KaigiPreviewContainer
 import io.github.droidkaigi.confsched.droidkaigiui.component.AnimatedTextTopAppBar
@@ -30,6 +31,8 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+
+const val TimetableUiTypeChangeTestTag = "TimetableUiTypeChangeTestTag"
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -61,6 +64,7 @@ fun TimetableTopAppBar(
             IconButton(
                 onClick = onUiTypeChangeClick,
                 shapes = IconButtonDefaults.shapes(),
+                modifier = Modifier.testTag(TimetableUiTypeChangeTestTag)
             ) {
                 val iconRes = when (timetableUiType) {
                     TimetableUiType.List -> SessionsRes.drawable.ic_view_grid

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/grid/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/grid/TimetableGrid.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.ScrollAxisRange
 import androidx.compose.ui.semantics.horizontalScrollAxisRange
 import androidx.compose.ui.semantics.scrollBy
@@ -74,6 +75,8 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.ExperimentalTime
+
+const val TimetableGridTestTag = "TimetableGridTestTag"
 
 @Composable
 fun TimetableGrid(
@@ -332,7 +335,8 @@ private fun TimetableGrid(
                         true
                     },
                 )
-            },
+            }
+            .testTag(TimetableGridTestTag),
     ) { constraint ->
         data class ItemData(val placeable: Placeable, val timetableItem: TimetableItemLayout)
         if (timetableGridState.width != constraint.maxWidth ||

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -95,7 +95,7 @@ class TimetableScreenTest {
                         doIt {
                             scrollTimetable()
                         }
-                        // TODO: Fix flaky test - Grid scroll behavior needs investigation
+                        // TODO: Fix fail test - Grid scroll behavior needs investigation
 //                        itShould("first session is not displayed") {
 //                            captureScreenWithChecks(checks = {
 //                                checkTimetableGridFirstItemNotDisplayed()

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -95,12 +95,11 @@ class TimetableScreenTest {
                         doIt {
                             scrollTimetable()
                         }
-                        // TODO: Fix fail test - Grid scroll behavior needs investigation
-//                        itShould("first session is not displayed") {
-//                            captureScreenWithChecks(checks = {
-//                                checkTimetableGridFirstItemNotDisplayed()
-//                            })
-//                        }
+                        itShould("first session is not displayed") {
+                            captureScreenWithChecks(checks = {
+                                checkTimetableGridFirstItemNotDisplayed()
+                            })
+                        }
                     }
                     describe("click conference day2 tab") {
                         doIt {

--- a/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/commonTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -53,6 +53,66 @@ class TimetableScreenTest {
                         clickFirstSessionBookmark()
                     }
                 }
+                describe("click first session") {
+                    doIt {
+                        clickFirstSession()
+                    }
+                    itShould("show session detail") {
+                        checkClickedItemsExists()
+                    }
+                }
+                describe("scroll timetable") {
+                    doIt {
+                        scrollTimetable()
+                    }
+                    itShould("first session is not displayed") {
+                        captureScreenWithChecks(checks = {
+                            checkTimetableListFirstItemNotDisplayed()
+                        })
+                    }
+                }
+                describe("click conference day2 tab") {
+                    doIt {
+                        clickTimetableTab(DroidKaigi2025Day.ConferenceDay2)
+                    }
+                    itShould("change displayed day") {
+                        captureScreenWithChecks(checks = {
+                            checkTimetableListItemsDisplayed()
+                        })
+                    }
+                }
+                describe("click timetable ui type change") {
+                    doIt {
+                        clickTimetableUiTypeChangeButton()
+                    }
+                    itShould("change timetable ui type") {
+                        captureScreenWithChecks(checks = {
+                            checkTimetableGridDisplayed()
+                            checkTimetableGridItemsDisplayed()
+                        })
+                    }
+                    describe("scroll timetable") {
+                        doIt {
+                            scrollTimetable()
+                        }
+                        // TODO: Fix flaky test - Grid scroll behavior needs investigation
+//                        itShould("first session is not displayed") {
+//                            captureScreenWithChecks(checks = {
+//                                checkTimetableGridFirstItemNotDisplayed()
+//                            })
+//                        }
+                    }
+                    describe("click conference day2 tab") {
+                        doIt {
+                            clickTimetableTab(DroidKaigi2025Day.ConferenceDay2)
+                        }
+                        itShould("change displayed day") {
+                            captureScreenWithChecks(checks = {
+                                checkTimetableGridItemsDisplayed()
+                            })
+                        }
+                    }
+                }
             }
         }
         describe("when server is error") {


### PR DESCRIPTION
## Issue
- close #316 

## Overview (Required)
- Created a test for the TimetableScreen based on last year's DroidKaigi app

## Links
DroidKaigi 2024 (for reference)
- [TimetableScreenTest.kt](https://github.com/DroidKaigi/conference-app-2024/blob/main/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt)
- [TimetableScreenRobot.kt](https://github.com/DroidKaigi/conference-app-2024/blob/main/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >

## ~~Concerns~~
~~The implementation for the following section, marked with TODO comments, has not been completed as I am unsure how to implement it...~~
- ~~The section where you can verify that session details are displayed~~
- ~~The section where you check if grid items are scrolled out of view~~
