### PR TITLE
Clean Up FIXME comments around the BookmarkData API

### DIFF
--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/PlatformFileExt.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/PlatformFileExt.kt
@@ -2,9 +2,4 @@ package io.github.confsched.profile
 
 import io.github.vinceglb.filekit.PlatformFile
 
-/**
- * TODO: Replace with an implementation using the BookmarkData API once the following issue is resolved
- *
- * [https://github.com/vinceglb/FileKit/issues/346](https://github.com/vinceglb/FileKit/issues/346)
- */
 expect fun PlatformFile.persistPermission()

--- a/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/io/github/confsched/profile/ProfileEditScreen.kt
@@ -1,6 +1,5 @@
 package io.github.confsched.profile
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -300,57 +299,6 @@ private fun Form<Profile>.Image() {
             }
         },
     )
-
-    // FIXME: Replace the ByteArray version once the following bug is fixed.
-    //   https://github.com/vinceglb/FileKit/issues/346
-    // var image: PlatformFile? by remember {
-    //     val file = if (value.image.isNotEmpty()) {
-    //         PlatformFile.fromBookmarkData(value.image)
-    //     } else {
-    //         null
-    //     }
-    //     mutableStateOf(file)
-    // }
-    // val coroutineScope = rememberCoroutineScope()
-    // Field(
-    //     selector = { it.image },
-    //     updater = { copy(image = it) },
-    //     validator = FieldValidator {
-    //         notEmpty { emptyImageErrorString }
-    //     },
-    //     render = { field ->
-    //         Column {
-    //             ImagePicker(
-    //                 image = image,
-    //                 onImageChange = { file ->
-    //                     image = file
-    //                     coroutineScope.launch {
-    //                         try {
-    //                             val bookmark = file.bookmarkData() // <-- Throw the exception
-    //                             field.onValueChange(bookmark.bytes)
-    //                         } catch (e: CancellationException) {
-    //                             throw e
-    //                         } catch (e: Exception) {
-    //                             field.onValueChange(ByteArray(0))
-    //                             println("Failed to load image: ${e.stackTraceToString()}")
-    //                         }
-    //                     }
-    //                 },
-    //                 onClear = {
-    //                     image = null
-    //                     field.onValueChange(ByteArray(0))
-    //                 }
-    //             )
-    //             if (field.hasError) {
-    //                 Text(
-    //                     text = field.error.messages.first(),
-    //                     color = MaterialTheme.colorScheme.error,
-    //                     style = MaterialTheme.typography.bodySmall,
-    //                 )
-    //             }
-    //         }
-    //     }
-    // )
 }
 
 @Composable


### PR DESCRIPTION
## Issue
- close #632 

## Overview (Required)
- I cleaned up FIXME comments around the BookmarkData API due to the decision not to migrate to the BookmarkData API.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
